### PR TITLE
feat: memory scoping by agent role

### DIFF
--- a/server/src/services/constitution-engine.ts
+++ b/server/src/services/constitution-engine.ts
@@ -390,6 +390,28 @@ export class ConstitutionEngine {
         }
       }
 
+      // -- Memory scoping based on agent role ---
+      const isChiefOfStaff = agent.isHeadButler || agent.staffRole === "head_butler";
+
+      // Load all member slugs for Chief of Staff "all" scope
+      let allMemberCollections: string[] | undefined;
+      let allowedCollections: string[];
+
+      if (isChiefOfStaff) {
+        // Chief of Staff can access all member collections + household
+        const allMembers = await this.db
+          .select({ name: familyMembers.name })
+          .from(familyMembers)
+          .where(eq(familyMembers.householdId, householdId));
+        allMemberCollections = allMembers.map(
+          (m) => m.name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, ""),
+        );
+        allowedCollections = [...allMemberCollections, "household"];
+      } else {
+        // Personal agents can only access their assigned member + household
+        allowedCollections = [memberSlug, "household"];
+      }
+
       const built = await this.toolRegistry.buildExecutor({
         db: this.db,
         memoryProvider: this.memoryProvider,
@@ -399,6 +421,9 @@ export class ConstitutionEngine {
         householdId,
         memberCollection: memberSlug,
         householdCollection: "household",
+        isChiefOfStaff,
+        allMemberCollections,
+        allowedCollections,
       });
 
       if (built) {

--- a/server/src/services/memory/memory-tools.ts
+++ b/server/src/services/memory/memory-tools.ts
@@ -29,7 +29,7 @@ export const MEMORY_TOOLS: ToolDefinition[] = [
   {
     name: "search_memory",
     description:
-      "Search your memory for relevant information. Use this before answering questions about the family, their preferences, past events, or commitments. Searches both the family member's personal memory and the shared household memory.",
+      "Search your memory for relevant information. Use this before answering questions about the family, their preferences, past events, or commitments. Default scope 'both' searches the family member's personal memory and shared household memory together.",
     input_schema: {
       type: "object",
       properties: {
@@ -40,9 +40,9 @@ export const MEMORY_TOOLS: ToolDefinition[] = [
         },
         scope: {
           type: "string",
-          enum: ["personal", "household", "both"],
+          enum: ["personal", "household", "both", "all"],
           description:
-            "Where to search. 'personal' = this member's memory. 'household' = shared family memory. 'both' = search both (default).",
+            "Where to search. 'personal' = this member's memory. 'household' = shared family memory. 'both' = personal + household (default). 'all' = every family member's memory + household (Chief of Staff only — use when you need info about another family member).",
         },
       },
       required: ["query"],
@@ -51,7 +51,7 @@ export const MEMORY_TOOLS: ToolDefinition[] = [
   {
     name: "save_memory",
     description:
-      "Save something to memory. IMPORTANT: Always search_memory first to check for existing entries on the same topic. If one exists, delete it first, then save the updated version. Never create duplicates. Save only lasting facts worth remembering — not every conversational detail.",
+      "Save something to memory. IMPORTANT: Always search_memory first to check for existing entries on the same topic. If one exists, use update_memory instead. Never create duplicates. Save only lasting facts worth remembering — not every conversational detail. Use 'personal' scope for things specific to this person (their preferences, their schedule, their goals). Use 'household' scope for things that affect the whole family (family events, shared decisions, household rules).",
     input_schema: {
       type: "object",
       properties: {
@@ -180,6 +180,12 @@ export interface ToolContext {
   memberCollection: string;
   /** The QMD collection name for shared household memory */
   householdCollection: string;
+  /** Whether this agent is the Chief of Staff (can search all collections) */
+  isChiefOfStaff?: boolean;
+  /** All member collection names in the household (for Chief of Staff "all" scope) */
+  allMemberCollections?: string[];
+  /** Collections this agent is allowed to read/write (for validation) */
+  allowedCollections?: string[];
 }
 
 // ── Executor factory ───────────────────────────────────────────────
@@ -240,16 +246,33 @@ async function handleSearchMemory(
   const query = input.query as string;
   const scope = (input.scope as string) ?? "both";
 
-  const results: Array<{ id: string; title: string; snippet: string; score: number; collection: string }> = [];
-
-  if (scope === "personal" || scope === "both") {
-    const personal = await ctx.memoryProvider.search(query, ctx.memberCollection, 5);
-    results.push(...personal.entries);
+  // "all" scope is only available to the Chief of Staff
+  if (scope === "all" && !ctx.isChiefOfStaff) {
+    return { content: "The 'all' search scope is only available to the Chief of Staff.", is_error: true };
   }
 
-  if (scope === "household" || scope === "both") {
-    const household = await ctx.memoryProvider.search(query, ctx.householdCollection, 3);
-    results.push(...household.entries);
+  const results: Array<{ id: string; title: string; snippet: string; score: number; collection: string }> = [];
+
+  if (scope === "all" && ctx.allMemberCollections) {
+    // Chief of Staff: search every member collection + household
+    const searches = ctx.allMemberCollections.map((col) =>
+      ctx.memoryProvider.search(query, col, 3),
+    );
+    searches.push(ctx.memoryProvider.search(query, ctx.householdCollection, 3));
+    const allResults = await Promise.all(searches);
+    for (const r of allResults) {
+      results.push(...r.entries);
+    }
+  } else {
+    if (scope === "personal" || scope === "both") {
+      const personal = await ctx.memoryProvider.search(query, ctx.memberCollection, 5);
+      results.push(...personal.entries);
+    }
+
+    if (scope === "household" || scope === "both") {
+      const household = await ctx.memoryProvider.search(query, ctx.householdCollection, 3);
+      results.push(...household.entries);
+    }
   }
 
   if (results.length === 0) {
@@ -258,7 +281,7 @@ async function handleSearchMemory(
 
   // Sort by score descending, take top results
   results.sort((a, b) => b.score - a.score);
-  const top = results.slice(0, 8);
+  const top = results.slice(0, 10);
 
   const formatted = top
     .map(
@@ -308,6 +331,11 @@ async function handleUpdateMemory(
   const content = input.content as string | undefined;
   const frontmatter = input.frontmatter as Record<string, unknown> | undefined;
 
+  // Validate collection access
+  if (ctx.allowedCollections && !ctx.allowedCollections.includes(collection)) {
+    return { content: `You don't have access to the "${collection}" collection.`, is_error: true };
+  }
+
   if (!title && !content && !frontmatter) {
     return { content: "Nothing to update — provide at least title, content, or frontmatter." };
   }
@@ -329,6 +357,11 @@ async function handleDeleteMemory(
 ): Promise<ToolResult> {
   const id = input.id as string;
   const collection = input.collection as string;
+
+  // Validate collection access
+  if (ctx.allowedCollections && !ctx.allowedCollections.includes(collection)) {
+    return { content: `You don't have access to the "${collection}" collection.`, is_error: true };
+  }
 
   await ctx.memoryProvider.delete(collection, id);
   return { content: `Memory "${id}" deleted from ${collection}.` };

--- a/server/src/services/tool-registry.ts
+++ b/server/src/services/tool-registry.ts
@@ -62,6 +62,12 @@ export interface ToolExecutionContext {
   householdId: string;
   memberCollection: string;
   householdCollection: string;
+  /** Whether this agent is the Chief of Staff (can search all collections) */
+  isChiefOfStaff?: boolean;
+  /** All member collection names in the household (for Chief of Staff "all" scope) */
+  allMemberCollections?: string[];
+  /** Collections this agent is allowed to read/write */
+  allowedCollections?: string[];
 }
 
 // ── Trust level → Claude Code built-in tools ────────────────────────
@@ -308,6 +314,9 @@ export class ToolRegistry {
         householdId: ctx.householdId,
         memberCollection: ctx.memberCollection,
         householdCollection: ctx.householdCollection,
+        isChiefOfStaff: ctx.isChiefOfStaff,
+        allMemberCollections: ctx.allMemberCollections,
+        allowedCollections: ctx.allowedCollections,
       };
       const built = buildToolExecutor(toolCtx);
       memoryExecutor = built.executor;


### PR DESCRIPTION
## Summary

Agents now have scoped memory access based on their role. Personal agents can only search/modify their assigned member's collection and the shared household collection. The Chief of Staff can search across all family members.

## Changes

- **search_memory** gets a new `"all"` scope (Chief of Staff only) that searches every member collection + household in parallel
- **update_memory / delete_memory** validate the collection against an allowedCollections list before permitting writes
- **save_memory** description updated to guide agents on personal vs household scope decisions
- **Constitution engine** loads all member slugs at conversation time and populates the scoping context based on agent role
- **ToolContext / ToolExecutionContext** extended with `isChiefOfStaff`, `allMemberCollections`, `allowedCollections`

## Memory hierarchy

| What | Where it goes | Who can read |
|------|--------------|-------------|
| Personal to one member | Member's collection (`scope: "personal"`) | That member's agent + Chief of Staff |
| Affects whole family | Household collection (`scope: "household"`) | Everyone |
| Cross-member lookup | All collections (`scope: "all"`) | Chief of Staff only |

## Type

- [x] New feature

## Testing

- [x] `pnpm typecheck` passes (zero errors)
- [x] `pnpm test` passes (79/79 tests)
- [ ] Manual: verify Chief of Staff can search with `scope: "all"`
- [ ] Manual: verify personal agent gets rejected when using `scope: "all"`
- [ ] Manual: verify personal agent can't delete from another member's collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)