### PR TITLE
fix: boot banner reads VERSION instead of hardcoded v0.1

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -14,8 +14,9 @@
  */
 
 import { createServer } from "node:http";
-import { mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
 import { createDb } from "@carsonos/db";
 import { getConfig } from "./config.js";
@@ -39,9 +40,22 @@ import { bootMemory } from "./services/memory/index.js";
 import { ToolRegistry } from "./services/tool-registry.js";
 import { GoogleCalendarProvider, CALENDAR_TOOLS, GMAIL_TOOLS, DRIVE_TOOLS } from "./services/google/index.js";
 
+// Read VERSION from the repo root (two levels up from server/src/). Single
+// source of truth — bumping VERSION at ship time updates the boot banner
+// without a separate code change.
+function readVersion(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const versionPath = join(here, "..", "..", "VERSION");
+    return readFileSync(versionPath, "utf8").trim();
+  } catch {
+    return "unknown";
+  }
+}
+
 const BANNER = [
   "",
-  " CarsonOS v0.1",
+  ` CarsonOS v${readVersion()}`,
   " Your family's values, your family's AI.",
   "",
 ].join("\n");


### PR DESCRIPTION
Surfaced during the retro after /ship bounced the server on v0.2.0 but the banner still printed `CarsonOS v0.1`.

`readVersion()` resolves the repo-root VERSION file relative to `server/src/index.ts` via `import.meta.url`, so any future VERSION bump updates the banner without a separate code change. Falls back to `unknown` if the file can't be read.

Tiny follow-up to PR #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)