### PR TITLE
feat: IMAP email integration via imapflow (iCloud/Apple Mail)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       grammy:
         specifier: ^1.35.0
         version: 1.42.0
+      imapflow:
+        specifier: ^1.3.2
+        version: 1.3.2
       pino:
         specifier: ^9.6.0
         version: 9.14.0
@@ -1990,6 +1993,9 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  '@zone-eu/mailsplit@5.4.9':
+    resolution: {integrity: sha512-Qq7k6FzA5SmGf5HFPcr17gE7M+O1gttlmWn7tlGUlhGsbbjUaBL/4cEWIwExeCzqu5+kyZJ91mcBZbQ9zEwwYA==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -2373,6 +2379,10 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  encoding-japanese@2.2.0:
+    resolution: {integrity: sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==}
+    engines: {node: '>=8.10.0'}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -2618,6 +2628,9 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  imapflow@1.3.2:
+    resolution: {integrity: sha512-lIhVpjAf+o/1SELeR34vqeoEjAyBOMd6xq2Vdx2E4XIRwDi5sfqfBqqr5YkTwp7G/Q3f5ACpU7/zuGklJeCj9Q==}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -2717,6 +2730,15 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  libbase64@1.3.0:
+    resolution: {integrity: sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==}
+
+  libmime@5.3.8:
+    resolution: {integrity: sha512-ZrCY+Q66mPvasAfjsQ/IgahzoBvfE1VdtGRpo1hwRB1oK3wJKxhKA3GOcd2a6j7AH5eMFccxK9fBoCpRZTf8ng==}
+
+  libqp@2.1.1:
+    resolution: {integrity: sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -2954,6 +2976,10 @@ packages:
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
+  nodemailer@8.0.5:
+    resolution: {integrity: sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==}
+    engines: {node: '>=6.0.0'}
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -3032,6 +3058,10 @@ packages:
 
   pino-std-serializers@7.1.0:
     resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
 
   pino@9.14.0:
     resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
@@ -3338,6 +3368,14 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks@2.8.7:
+    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -3429,6 +3467,10 @@ packages:
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -5087,6 +5129,12 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@zone-eu/mailsplit@5.4.9':
+    dependencies:
+      libbase64: 1.3.0
+      libmime: 5.3.8
+      libqp: 2.1.1
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -5361,6 +5409,8 @@ snapshots:
   electron-to-chromium@1.5.331: {}
 
   encodeurl@2.0.0: {}
+
+  encoding-japanese@2.2.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -5752,6 +5802,18 @@ snapshots:
 
   ieee754@1.2.1: {}
 
+  imapflow@1.3.2:
+    dependencies:
+      '@zone-eu/mailsplit': 5.4.9
+      encoding-japanese: 2.2.0
+      iconv-lite: 0.7.2
+      libbase64: 1.3.0
+      libmime: 5.3.8
+      libqp: 2.1.1
+      nodemailer: 8.0.5
+      pino: 10.3.1
+      socks: 2.8.7
+
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
@@ -5819,6 +5881,17 @@ snapshots:
   json-schema-typed@8.0.2: {}
 
   json5@2.2.3: {}
+
+  libbase64@1.3.0: {}
+
+  libmime@5.3.8:
+    dependencies:
+      encoding-japanese: 2.2.0
+      iconv-lite: 0.7.2
+      libbase64: 1.3.0
+      libqp: 2.1.1
+
+  libqp@2.1.1: {}
 
   lilconfig@3.1.3: {}
 
@@ -6241,6 +6314,8 @@ snapshots:
 
   node-releases@2.0.37: {}
 
+  nodemailer@8.0.5: {}
+
   normalize-path@3.0.0: {}
 
   object-assign@4.1.1: {}
@@ -6314,6 +6389,20 @@ snapshots:
       strip-json-comments: 5.0.3
 
   pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.0.0
 
   pino@9.14.0:
     dependencies:
@@ -6721,6 +6810,13 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
 
+  smart-buffer@4.2.0: {}
+
+  socks@2.8.7:
+    dependencies:
+      ip-address: 10.1.0
+      smart-buffer: 4.2.0
+
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
@@ -6843,6 +6939,10 @@ snapshots:
       any-promise: 1.3.0
 
   thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
+
+  thread-stream@4.0.0:
     dependencies:
       real-require: 0.2.0
 

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
     "esbuild": "^0.28.0",
     "express": "^5.1.0",
     "grammy": "^1.35.0",
+    "imapflow": "^1.3.2",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "sharp": "^0.34.5",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -41,6 +41,7 @@ import { hydrateEnvFromSettings } from "./services/env-hydration.js";
 import { ToolRegistry } from "./services/tool-registry.js";
 import { GoogleCalendarProvider, CALENDAR_TOOLS, GMAIL_TOOLS, DRIVE_TOOLS } from "./services/google/index.js";
 import { CalDavProvider, CALDAV_CALENDAR_TOOLS } from "./services/caldav/index.js";
+import { ImapProvider, IMAP_EMAIL_TOOLS } from "./services/imap/index.js";
 
 // Read VERSION from the repo root (two levels up from server/src/). Single
 // source of truth — bumping VERSION at ship time updates the boot banner
@@ -116,7 +117,7 @@ async function main() {
     console.warn("[memory] Boot failed, running without memory:", err);
   }
 
-  // 2c. Calendar providers
+  // 2c. External providers
   const googleDir = join(config.dataDir, "google");
   const calendarProvider = new GoogleCalendarProvider(googleDir);
   const gwsHealthy = await calendarProvider.healthCheck();
@@ -128,6 +129,12 @@ async function main() {
   const caldavDir = join(config.dataDir, "caldav");
   const caldavProvider = new CalDavProvider(caldavDir);
   console.log("[caldav] Calendar provider ready");
+
+  // IMAP — always available, no external CLI dependency.
+  // Per-member credentials resolved at dispatch time.
+  const imapDir = join(config.dataDir, "imap");
+  const imapProvider = new ImapProvider(imapDir);
+  console.log("[imap] Email provider ready");
 
   // 2d. Tool registry
   const toolRegistry = new ToolRegistry(db);
@@ -169,6 +176,17 @@ async function main() {
     );
   }
 
+  // Register IMAP email tools (always available — per-member auth checked at call time)
+  const imapPlaceholder = async (_name: string, _input: Record<string, unknown>) => ({
+    content: "IMAP not configured for this member. Save credentials to ~/.carsonos/imap/<member>/credentials.json",
+    is_error: true as const,
+  });
+
+  toolRegistry.registerAll(
+    IMAP_EMAIL_TOOLS.map((def) => ({ definition: def, category: "email", tier: "builtin" as const })),
+    imapPlaceholder,
+  );
+
   // Skills are enabled via trust level ("Skill" built-in for full trust).
   // No need to discover/register them — the SDK handles skill loading.
 
@@ -187,6 +205,7 @@ async function main() {
     toolRegistry,
     calendarProvider: gwsHealthy ? calendarProvider : undefined,
     caldavProvider,
+    imapProvider,
     featureFlags: config.featureFlags,
   });
   console.log("[engine] Constitution engine ready");

--- a/server/src/services/constitution-engine.ts
+++ b/server/src/services/constitution-engine.ts
@@ -53,6 +53,8 @@ import type { GoogleCalendarProvider } from "./google/index.js";
 import { createCalendarToolHandler, createGmailToolHandler, createDriveToolHandler } from "./google/index.js";
 import type { CalDavProvider } from "./caldav/index.js";
 import { createCalDavCalendarToolHandler } from "./caldav/index.js";
+import type { ImapProvider } from "./imap/index.js";
+import { createImapEmailToolHandler } from "./imap/index.js";
 
 // -- Types -----------------------------------------------------------
 
@@ -92,6 +94,7 @@ export interface EngineConfig {
   toolRegistry?: ToolRegistry;
   calendarProvider?: GoogleCalendarProvider;
   caldavProvider?: CalDavProvider;
+  imapProvider?: ImapProvider;
   multiRelay?: import("./multi-relay-manager.js").MultiRelayManager;
   /** Feature flags — v1.0 ships with hardEvaluators OFF */
   featureFlags?: {
@@ -227,6 +230,7 @@ export class ConstitutionEngine {
   private toolRegistry: ToolRegistry | null;
   private calendarProvider: GoogleCalendarProvider | null;
   private caldavProvider: CalDavProvider | null;
+  private imapProvider: ImapProvider | null;
   private hardEvaluatorsEnabled: boolean;
   private multiRelay: import("./multi-relay-manager.js").MultiRelayManager | null;
 
@@ -238,6 +242,7 @@ export class ConstitutionEngine {
     this.toolRegistry = config.toolRegistry ?? null;
     this.calendarProvider = config.calendarProvider ?? null;
     this.caldavProvider = config.caldavProvider ?? null;
+    this.imapProvider = config.imapProvider ?? null;
     this.multiRelay = config.multiRelay ?? null;
     this.hardEvaluatorsEnabled = config.featureFlags?.hardEvaluators ?? false;
   }
@@ -563,6 +568,17 @@ export class ConstitutionEngine {
             return base(name, input);
           };
         }
+
+        // Same pattern for IMAP email tools.
+        if (this.imapProvider && this.imapProvider.getAuthStatus(memberSlug).authenticated) {
+          const imapHandler = createImapEmailToolHandler(this.imapProvider, memberSlug);
+          const imapToolNames = new Set(["imap_triage", "imap_read", "imap_search"]);
+          const base = toolExecutor;
+          toolExecutor = async (name: string, input: Record<string, unknown>) => {
+            if (imapToolNames.has(name)) return imapHandler(name, input);
+            return base(name, input);
+          };
+        }
       }
 
       // Expose a refresh callback to the adapter so mid-session custom tool
@@ -577,6 +593,15 @@ export class ConstitutionEngine {
           const base = refreshedExecutor;
           refreshedExecutor = async (name: string, input: Record<string, unknown>) => {
             if (caldavToolNames.has(name)) return caldavHandler(name, input);
+            return base(name, input);
+          };
+        }
+        if (this.imapProvider && this.imapProvider.getAuthStatus(memberSlug).authenticated) {
+          const imapHandler = createImapEmailToolHandler(this.imapProvider, memberSlug);
+          const imapToolNames = new Set(["imap_triage", "imap_read", "imap_search"]);
+          const base = refreshedExecutor;
+          refreshedExecutor = async (name: string, input: Record<string, unknown>) => {
+            if (imapToolNames.has(name)) return imapHandler(name, input);
             return base(name, input);
           };
         }

--- a/server/src/services/imap/email-tools.ts
+++ b/server/src/services/imap/email-tools.ts
@@ -1,0 +1,162 @@
+/**
+ * IMAP email tool definitions + handler.
+ *
+ * Tools (read-only):
+ *   - imap_triage  — "Any important emails?" — recent unread messages summary
+ *   - imap_read    — "Read that email from Tyler" — full content by message ID
+ *   - imap_search  — "Find emails about the invoice" — search by Gmail-style query
+ *
+ * Message IDs use format "<mailbox>:<uid>" (e.g. "INBOX:12345").
+ * No send, compose, draft, reply, or delete tools — read-only.
+ */
+
+import type { ToolDefinition, ToolResult } from "@carsonos/shared";
+import type { ImapProvider } from "./imap-provider.js";
+
+export const IMAP_EMAIL_TOOLS: ToolDefinition[] = [
+  {
+    name: "imap_triage",
+    description:
+      "Check the email inbox for recent or unread messages. Shows sender, subject, and date for each. Use when someone asks about their email, inbox, or if anything important came in.",
+    input_schema: {
+      type: "object",
+      properties: {
+        mailbox: {
+          type: "string",
+          description: "Mailbox to check (default: INBOX).",
+        },
+        max: {
+          type: "number",
+          description: "Maximum number of messages to return (default: 20).",
+        },
+        unreadOnly: {
+          type: "boolean",
+          description:
+            "If true, only return unread messages. If false, return all recent messages. Default: true.",
+        },
+      },
+    },
+  },
+  {
+    name: "imap_read",
+    description:
+      "Read the full content of a specific email by its message ID. Message IDs come from imap_triage or imap_search results. Use when someone wants to read, open, or see the details of a specific email.",
+    input_schema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          description:
+            'Message ID to read (format: "<mailbox>:<uid>", e.g. "INBOX:12345"). Obtained from imap_triage or imap_search.',
+        },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "imap_search",
+    description:
+      'Search email messages by query. Supports Gmail-style operators: from:address, to:address, subject:text, body:text, before:YYYY-MM-DD, after:YYYY-MM-DD, is:unread, is:read, is:flagged. Unrecognised terms are full-text searched. Example: "from:boss is:unread" or "subject:invoice after:2026-01-01".',
+    input_schema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description:
+            'Search query using Gmail-style operators, e.g. "from:tyler soccer" or "subject:invoice is:unread".',
+        },
+        mailbox: {
+          type: "string",
+          description: "Mailbox to search (default: INBOX).",
+        },
+        max: {
+          type: "number",
+          description: "Maximum number of results (default: 20).",
+        },
+      },
+      required: ["query"],
+    },
+  },
+];
+
+// ── Handler ────────────────────────────────────────────────────────
+
+export function createImapEmailToolHandler(
+  provider: ImapProvider,
+  memberSlug: string,
+): (name: string, input: Record<string, unknown>) => Promise<ToolResult> {
+  return async (name, input) => {
+    try {
+      switch (name) {
+        case "imap_triage": {
+          const messages = await provider.triageInbox(memberSlug, {
+            mailbox: input.mailbox as string | undefined,
+            max: input.max as number | undefined,
+            unreadOnly: input.unreadOnly as boolean | undefined,
+          });
+
+          if (messages.length === 0) {
+            const qualifier =
+              input.unreadOnly === false ? "recent" : "unread";
+            return { content: `No ${qualifier} messages.` };
+          }
+
+          const lines = messages.map(
+            (m) => `- ${m.from}: ${m.subject} (${m.date}) [id: ${m.id}]`,
+          );
+          return {
+            content: `${messages.length} message(s):\n${lines.join("\n")}`,
+          };
+        }
+
+        case "imap_read": {
+          const message = await provider.readMessage(
+            memberSlug,
+            input.id as string,
+          );
+
+          const parts: string[] = [
+            `From: ${message.from}`,
+          ];
+          if (message.to) parts.push(`To: ${message.to}`);
+          parts.push(`Subject: ${message.subject}`);
+          parts.push(`Date: ${message.date}`);
+          parts.push("");
+          parts.push(message.body ?? "(empty)");
+
+          return { content: parts.join("\n") };
+        }
+
+        case "imap_search": {
+          const messages = await provider.searchMessages(
+            memberSlug,
+            input.query as string,
+            {
+              mailbox: input.mailbox as string | undefined,
+              max: input.max as number | undefined,
+            },
+          );
+
+          if (messages.length === 0) {
+            return {
+              content: `No messages found matching "${input.query}".`,
+            };
+          }
+
+          const lines = messages.map(
+            (m) => `- ${m.from}: ${m.subject} (${m.date}) [id: ${m.id}]`,
+          );
+          return {
+            content: `${messages.length} message(s):\n${lines.join("\n")}`,
+          };
+        }
+
+        default:
+          return { content: `Unknown IMAP tool: ${name}`, is_error: true };
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: `IMAP error: ${msg}`, is_error: true };
+    }
+  };
+}

--- a/server/src/services/imap/imap-provider.ts
+++ b/server/src/services/imap/imap-provider.ts
@@ -1,0 +1,589 @@
+/**
+ * IMAP email provider — wraps imapflow for read-only email operations.
+ *
+ * Each family member gets their own credentials file so they authenticate
+ * with their own email account (iCloud, Gmail, Fastmail, etc.).
+ *
+ * Credentials are stored at:
+ *   ~/.carsonos/imap/<memberSlug>/credentials.json
+ *
+ * Dependency: `imapflow` npm package (included in server deps)
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { ImapFlow } from "imapflow";
+import type { SearchObject, FetchMessageObject } from "imapflow";
+
+const TIMEOUT_MS = 30_000;
+const BODY_MAX_CHARS = 8_000;
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export interface ImapCredentials {
+  host: string;
+  port: number;
+  username: string;
+  password: string;
+}
+
+export interface ImapAuthStatus {
+  authenticated: boolean;
+  credentialsPath: string;
+}
+
+export interface EmailMessage {
+  /**
+   * Stable message identifier in the format "<mailbox>:<uid>".
+   * e.g. "INBOX:12345"  — pass this to readMessage() / imap_read.
+   */
+  id: string;
+  from: string;
+  to?: string;
+  subject: string;
+  date: string;
+  body?: string;
+  mailbox?: string;
+}
+
+// ── Provider ───────────────────────────────────────────────────────
+
+export class ImapProvider {
+  private rootDir: string;
+
+  constructor(rootDir: string) {
+    this.rootDir = rootDir;
+    mkdirSync(rootDir, { recursive: true });
+  }
+
+  // ── Directory / credential helpers ───────────────────────────────
+
+  private memberDir(memberSlug: string): string {
+    const dir = join(this.rootDir, memberSlug);
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  private credentialsPath(memberSlug: string): string {
+    return join(this.memberDir(memberSlug), "credentials.json");
+  }
+
+  private loadCredentials(memberSlug: string): ImapCredentials {
+    const path = this.credentialsPath(memberSlug);
+    if (!existsSync(path)) {
+      throw new Error(
+        `IMAP not configured for this member. Create ${path} with fields: host, port, username, password`,
+      );
+    }
+    try {
+      return JSON.parse(readFileSync(path, "utf8")) as ImapCredentials;
+    } catch {
+      throw new Error(
+        `Failed to read IMAP credentials at ${path}. Check that the file is valid JSON.`,
+      );
+    }
+  }
+
+  private createClient(creds: ImapCredentials): ImapFlow {
+    return new ImapFlow({
+      host: creds.host,
+      port: creds.port,
+      secure: creds.port === 993,
+      auth: { user: creds.username, pass: creds.password },
+      logger: false,
+    });
+  }
+
+  // ── Auth ─────────────────────────────────────────────────────────
+
+  /** Check if a member has a credentials file saved. */
+  getAuthStatus(memberSlug: string): ImapAuthStatus {
+    const path = this.credentialsPath(memberSlug);
+    return { authenticated: existsSync(path), credentialsPath: path };
+  }
+
+  /**
+   * Save credentials for a member. Writes credentials.json to the member's
+   * IMAP directory. The server is not contacted — call triageInbox() to
+   * verify the credentials work.
+   */
+  saveCredentials(memberSlug: string, credentials: ImapCredentials): string {
+    const path = this.credentialsPath(memberSlug);
+    writeFileSync(path, JSON.stringify(credentials, null, 2), "utf8");
+    return path;
+  }
+
+  // ── Email operations ─────────────────────────────────────────────
+
+  /**
+   * Triage the inbox: return the N most recent unread (or all) messages.
+   * Returns envelope info only — use readMessage() for full content.
+   *
+   * opts.mailbox    — mailbox to open (default: "INBOX")
+   * opts.max        — max messages to return (default: 20)
+   * opts.unreadOnly — only return unseen messages (default: true)
+   */
+  async triageInbox(
+    memberSlug: string,
+    opts?: { mailbox?: string; max?: number; unreadOnly?: boolean },
+  ): Promise<EmailMessage[]> {
+    const creds = this.loadCredentials(memberSlug);
+    const client = this.createClient(creds);
+    const mailbox = opts?.mailbox ?? "INBOX";
+    const max = opts?.max ?? 20;
+    const unreadOnly = opts?.unreadOnly ?? true;
+
+    await withTimeout(client.connect(), TIMEOUT_MS);
+    try {
+      const lock = await withTimeout(client.getMailboxLock(mailbox), TIMEOUT_MS);
+      try {
+        const query: SearchObject = unreadOnly ? { seen: false } : { all: true };
+        const uids = await withTimeout(client.search(query, { uid: true }), TIMEOUT_MS);
+
+        if (!uids || uids.length === 0) return [];
+
+        // Take the last `max` UIDs (highest = most recently received)
+        const recent = (uids as number[]).slice(-max);
+        return await fetchEnvelopes(client, recent, mailbox);
+      } finally {
+        lock.release();
+      }
+    } finally {
+      await client.logout().catch(() => {});
+    }
+  }
+
+  /**
+   * Read the full content of a specific message by ID.
+   * messageId format: "<mailbox>:<uid>"  (from triageInbox / searchMessages).
+   */
+  async readMessage(memberSlug: string, messageId: string): Promise<EmailMessage> {
+    const creds = this.loadCredentials(memberSlug);
+    const client = this.createClient(creds);
+    const { mailbox, uid } = parseMessageId(messageId);
+
+    await withTimeout(client.connect(), TIMEOUT_MS);
+    try {
+      const lock = await withTimeout(client.getMailboxLock(mailbox), TIMEOUT_MS);
+      try {
+        const msg = await withTimeout(
+          client.fetchOne(uid, { envelope: true, source: true, uid: true }, { uid: true }),
+          TIMEOUT_MS,
+        );
+
+        if (!msg) {
+          throw new Error(`Message not found: ${messageId}`);
+        }
+
+        const body = msg.source ? extractBody(msg.source.toString("binary")) : undefined;
+
+        return {
+          id: messageId,
+          from: formatAddresses(msg.envelope?.from),
+          to: formatAddresses(msg.envelope?.to),
+          subject: msg.envelope?.subject ?? "(no subject)",
+          date: msg.envelope?.date ? formatDate(msg.envelope.date) : "",
+          body,
+          mailbox,
+        };
+      } finally {
+        lock.release();
+      }
+    } finally {
+      await client.logout().catch(() => {});
+    }
+  }
+
+  /**
+   * Search messages using a Gmail-style query string.
+   * Supported operators: from:, to:, subject:, body:, before:, after:, is:unread, is:read, is:flagged
+   * Unrecognised terms are used as full-text search.
+   *
+   * opts.mailbox — mailbox to search (default: "INBOX")
+   * opts.max     — max results (default: 20)
+   */
+  async searchMessages(
+    memberSlug: string,
+    query: string,
+    opts?: { mailbox?: string; max?: number },
+  ): Promise<EmailMessage[]> {
+    const creds = this.loadCredentials(memberSlug);
+    const client = this.createClient(creds);
+    const mailbox = opts?.mailbox ?? "INBOX";
+    const max = opts?.max ?? 20;
+
+    await withTimeout(client.connect(), TIMEOUT_MS);
+    try {
+      const lock = await withTimeout(client.getMailboxLock(mailbox), TIMEOUT_MS);
+      try {
+        const searchObj = parseSearchQuery(query);
+        const uids = await withTimeout(client.search(searchObj, { uid: true }), TIMEOUT_MS);
+
+        if (!uids || uids.length === 0) return [];
+
+        const recent = (uids as number[]).slice(-max);
+        return await fetchEnvelopes(client, recent, mailbox);
+      } finally {
+        lock.release();
+      }
+    } finally {
+      await client.logout().catch(() => {});
+    }
+  }
+
+  /**
+   * IMAP is always available (it's an npm package, not an external CLI).
+   * Returns true unconditionally — per-member auth is checked via getAuthStatus().
+   */
+  async healthCheck(): Promise<boolean> {
+    return true;
+  }
+}
+
+// ── Shared fetch helper ────────────────────────────────────────────
+
+/**
+ * Fetch envelope data for a list of UIDs from the currently-locked mailbox.
+ * Returns EmailMessage objects sorted newest-first (no body content).
+ */
+async function fetchEnvelopes(
+  client: ImapFlow,
+  uids: number[],
+  mailbox: string,
+): Promise<EmailMessage[]> {
+  const messages: EmailMessage[] = [];
+
+  for await (const msg of client.fetch(
+    uids,
+    { envelope: true, uid: true },
+    { uid: true },
+  ) as AsyncIterable<FetchMessageObject>) {
+    messages.push({
+      id: `${mailbox}:${msg.uid}`,
+      from: formatAddresses(msg.envelope?.from),
+      to: formatAddresses(msg.envelope?.to),
+      subject: msg.envelope?.subject ?? "(no subject)",
+      date: msg.envelope?.date ? formatDate(msg.envelope.date) : "",
+      mailbox,
+    });
+  }
+
+  // Reverse so newest (highest UID) appears first
+  return messages.reverse();
+}
+
+// ── Message ID helpers ─────────────────────────────────────────────
+
+/** Parse a message ID in format "<mailbox>:<uid>". */
+function parseMessageId(messageId: string): { mailbox: string; uid: number } {
+  const colonIdx = messageId.lastIndexOf(":");
+  if (colonIdx < 0) {
+    throw new Error(
+      `Invalid message ID format: "${messageId}". Expected "<mailbox>:<uid>", e.g. "INBOX:12345".`,
+    );
+  }
+  const mailbox = messageId.slice(0, colonIdx) || "INBOX";
+  const uid = parseInt(messageId.slice(colonIdx + 1), 10);
+  if (isNaN(uid)) {
+    throw new Error(`Invalid UID in message ID: "${messageId}".`);
+  }
+  return { mailbox, uid };
+}
+
+/** Format an array of address objects to a readable string. */
+function formatAddresses(
+  addrs?: Array<{ name?: string; address?: string }>,
+): string {
+  if (!addrs || addrs.length === 0) return "";
+  return addrs
+    .map((a) => {
+      if (a.name && a.address) return `${a.name} <${a.address}>`;
+      return a.address ?? a.name ?? "";
+    })
+    .join(", ");
+}
+
+/** Format a Date to a locale-friendly string. */
+function formatDate(d: Date | string): string {
+  const date = d instanceof Date ? d : new Date(d);
+  if (isNaN(date.getTime())) return String(d);
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// ── MIME body extraction ───────────────────────────────────────────
+
+/**
+ * Extract readable plain text from a raw RFC 5322 message string.
+ * Handles multipart, base64/quoted-printable encoding, and HTML stripping.
+ */
+function extractBody(raw: string): string {
+  const { headers, body } = splitHeadersBody(raw);
+  const contentType = getHeader(headers, "content-type") ?? "text/plain";
+  const encoding = (getHeader(headers, "content-transfer-encoding") ?? "7bit")
+    .toLowerCase()
+    .trim();
+
+  let text: string;
+  if (/multipart\//i.test(contentType)) {
+    const boundary = extractBoundary(contentType);
+    text = boundary ? extractMultipartText(body, boundary) : body;
+  } else {
+    text = decodeBody(body, encoding);
+    if (/text\/html/i.test(contentType)) {
+      text = stripHtml(text);
+    }
+  }
+
+  // Normalise whitespace and truncate
+  text = text.replace(/\r\n/g, "\n").replace(/[ \t]+$/gm, "").trim();
+  if (text.length > BODY_MAX_CHARS) {
+    text = `${text.slice(0, BODY_MAX_CHARS)}\n\n[… truncated]`;
+  }
+  return text;
+}
+
+/** Split a raw RFC 5322 message into unfolded headers and body. */
+function splitHeadersBody(raw: string): { headers: string; body: string } {
+  // CRLF blank line separates headers from body
+  const crlfSep = raw.indexOf("\r\n\r\n");
+  if (crlfSep >= 0) {
+    return {
+      headers: unfoldHeaders(raw.slice(0, crlfSep)),
+      body: raw.slice(crlfSep + 4),
+    };
+  }
+  // LF-only fallback
+  const lfSep = raw.indexOf("\n\n");
+  if (lfSep >= 0) {
+    return {
+      headers: unfoldHeaders(raw.slice(0, lfSep)),
+      body: raw.slice(lfSep + 2),
+    };
+  }
+  return { headers: unfoldHeaders(raw), body: "" };
+}
+
+/** RFC 5322 header unfolding: CRLF/LF followed by whitespace is a continuation. */
+function unfoldHeaders(block: string): string {
+  return block.replace(/\r\n([ \t])/g, "$1").replace(/\n([ \t])/g, "$1");
+}
+
+/** Get a named header value from an unfolded header block (case-insensitive). */
+function getHeader(headers: string, name: string): string | undefined {
+  const re = new RegExp(`^${name}:\\s*(.+)`, "im");
+  const m = re.exec(headers);
+  return m ? m[1].trim() : undefined;
+}
+
+/** Extract the `boundary` parameter from a Content-Type value. */
+function extractBoundary(contentType: string): string | undefined {
+  const m = /boundary="?([^";,\s]+)"?/i.exec(contentType);
+  return m ? m[1] : undefined;
+}
+
+/**
+ * Recursively walk a MIME multipart body and return the best plain-text content.
+ * Prefers text/plain parts; falls back to text/html → strip.
+ */
+function extractMultipartText(body: string, boundary: string): string {
+  const delimiter = `--${boundary}`;
+  const parts = body.split(delimiter);
+  let plainText = "";
+  let htmlFallback = "";
+
+  for (const part of parts) {
+    const trimmed = part.trim();
+    if (!trimmed || trimmed === "--" || trimmed.startsWith("--")) continue;
+
+    const { headers: partHeaders, body: partBody } = splitHeadersBody(part);
+    const partContentType = (
+      getHeader(partHeaders, "content-type") ?? "text/plain"
+    ).toLowerCase();
+    const partEncoding = (
+      getHeader(partHeaders, "content-transfer-encoding") ?? "7bit"
+    )
+      .toLowerCase()
+      .trim();
+
+    if (partContentType.startsWith("multipart/")) {
+      const subBoundary = extractBoundary(partContentType);
+      if (subBoundary) {
+        const sub = extractMultipartText(partBody, subBoundary);
+        if (sub) plainText += sub;
+        continue;
+      }
+    }
+
+    if (partContentType.startsWith("text/plain")) {
+      plainText += decodeBody(partBody, partEncoding);
+    } else if (partContentType.startsWith("text/html") && !plainText) {
+      htmlFallback = decodeBody(partBody, partEncoding);
+    }
+  }
+
+  if (plainText) return plainText;
+  if (htmlFallback) return stripHtml(htmlFallback);
+  return "";
+}
+
+/** Decode a MIME body based on its Content-Transfer-Encoding. */
+function decodeBody(body: string, encoding: string): string {
+  switch (encoding) {
+    case "base64":
+      try {
+        return Buffer.from(body.replace(/\s+/g, ""), "base64").toString("utf8");
+      } catch {
+        return body;
+      }
+    case "quoted-printable":
+      return decodeQuotedPrintable(body);
+    default:
+      // 7bit, 8bit, binary — return as-is
+      return body;
+  }
+}
+
+/** Decode quoted-printable encoded content. */
+function decodeQuotedPrintable(qp: string): string {
+  return (
+    qp
+      // Soft line breaks (= at end of line)
+      .replace(/=\r\n/g, "")
+      .replace(/=\n/g, "")
+      // Encoded bytes: =XX
+      .replace(/=([0-9A-Fa-f]{2})/g, (_, hex) =>
+        String.fromCharCode(parseInt(hex, 16)),
+      )
+  );
+}
+
+/** Strip HTML tags and decode common HTML entities. */
+function stripHtml(html: string): string {
+  return html
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/(?:p|div|tr|li|blockquote)>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .replace(/&[a-z]+;/gi, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+// ── Search query parser ────────────────────────────────────────────
+
+/**
+ * Parse a Gmail-style search query string into an imapflow SearchObject.
+ *
+ * Supported operators:
+ *   from:address     — sender matches
+ *   to:address       — recipient matches
+ *   cc:address       — CC matches
+ *   subject:text     — subject matches
+ *   body:text        — body matches
+ *   before:YYYY-MM-DD — received before date
+ *   after:YYYY-MM-DD  — received after date (alias: since:)
+ *   is:unread        — unseen messages
+ *   is:read          — seen messages
+ *   is:flagged       — flagged messages
+ *   is:unflagged     — unflagged messages
+ *   is:answered      — answered messages
+ *
+ * Unrecognised tokens are combined into a full-text search.
+ */
+function parseSearchQuery(query: string): SearchObject {
+  const tokens = tokenize(query);
+  const obj: SearchObject = {};
+  const textParts: string[] = [];
+
+  for (const token of tokens) {
+    const colonIdx = token.indexOf(":");
+    if (colonIdx > 0) {
+      const key = token.slice(0, colonIdx).toLowerCase();
+      const value = token.slice(colonIdx + 1).replace(/^"|"$/g, "");
+
+      switch (key) {
+        case "from":    obj.from = value; break;
+        case "to":      obj.to = value; break;
+        case "cc":      obj.cc = value; break;
+        case "bcc":     obj.bcc = value; break;
+        case "subject": obj.subject = value; break;
+        case "body":    obj.body = value; break;
+        case "text":    obj.text = value; break;
+        case "before":  obj.before = parseQueryDate(value); break;
+        case "after":
+        case "since":   obj.since = parseQueryDate(value); break;
+        case "is": {
+          switch (value.toLowerCase()) {
+            case "unread":     obj.seen = false; break;
+            case "read":       obj.seen = true; break;
+            case "flagged":    obj.flagged = true; break;
+            case "unflagged":  obj.flagged = false; break;
+            case "answered":   obj.answered = true; break;
+            case "unanswered": obj.answered = false; break;
+          }
+          break;
+        }
+        default:
+          textParts.push(token);
+      }
+    } else {
+      textParts.push(token);
+    }
+  }
+
+  if (textParts.length > 0) {
+    obj.text = textParts.join(" ");
+  }
+
+  // Default to all messages if no criteria specified
+  if (Object.keys(obj).length === 0) {
+    obj.all = true;
+  }
+
+  return obj;
+}
+
+/** Tokenise a query string, respecting double-quoted phrases. */
+function tokenize(query: string): string[] {
+  const tokens: string[] = [];
+  const re = /[^\s"]+(?:"[^"]*"[^\s"]*)*|"[^"]*"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(query)) !== null) {
+    tokens.push(m[0]);
+  }
+  return tokens;
+}
+
+/** Parse a date string (YYYY-MM-DD or natural) into a Date for IMAP search. */
+function parseQueryDate(value: string): Date {
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? new Date() : d;
+}
+
+// ── Utility ────────────────────────────────────────────────────────
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error(`IMAP request timed out after ${ms}ms`)),
+        ms,
+      ),
+    ),
+  ]);
+}

--- a/server/src/services/imap/index.ts
+++ b/server/src/services/imap/index.ts
@@ -1,0 +1,3 @@
+export { ImapProvider } from "./imap-provider.js";
+export type { ImapCredentials, ImapAuthStatus, EmailMessage } from "./imap-provider.js";
+export { IMAP_EMAIL_TOOLS, createImapEmailToolHandler } from "./email-tools.js";


### PR DESCRIPTION
## Summary

Adds read-only IMAP email access for agents, using imapflow. Designed for iCloud/Apple Mail but works with any standard IMAP server.

## What's included

- `server/src/services/imap/imap-provider.ts` — ImapProvider class using imapflow. Credentials stored at `~/.carsonos/imap/<memberSlug>/credentials.json`.
- `server/src/services/imap/email-tools.ts` — three read-only tools: imap_triage, imap_read, imap_search
- `server/src/services/imap/index.ts` — barrel exports
- Server wiring — ImapProvider initialized at boot, per-member handler bound in constitution-engine.ts for members with credentials saved

## Tools

- `imap_triage` — check inbox for recent/unread messages, shows sender, subject, date
- `imap_read` — read full content of a specific message by ID
- `imap_search` — search messages using Gmail-style operators (from:, to:, subject:, before:, after:, is:unread, etc.)

## Read-only

No send, compose, draft, or delete operations. Agents can read and report on email only.

## Setup

Generate an app-specific password at appleid.apple.com → Sign-In & Security → App-Specific Passwords, then save credentials:

mkdir -p ~/.carsonos/imap/<member>
cat > ~/.carsonos/imap/<member>/credentials.json << 'EOF'
{
  "host": "imap.mail.me.com",
  "port": 993,
  "username": "you@icloud.com",
  "password": "xxxx-xxxx-xxxx-xxxx"
}
EOF

## Notes

- Tested on macOS against iCloud IMAP
- Message IDs use <mailbox>:<uid> format (e.g. INBOX:37444) so agents can re-open the correct mailbox when reading a specific message
- MIME parsing handles RFC 5322 header unfolding, multipart boundary splitting, base64/QP decoding, HTML stripping, 8000-char truncation