### PR TITLE
feat: Signal transport via signal-cli SSE

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -46,6 +46,7 @@ CREATE TABLE family_members (
   role TEXT NOT NULL,
   age INTEGER NOT NULL,
   telegram_user_id TEXT UNIQUE,
+  signal_number TEXT UNIQUE,
   profile_content TEXT,
   profile_updated_at INTEGER,
   memory_dir TEXT,
@@ -63,6 +64,8 @@ CREATE TABLE staff_agents (
   soul_content TEXT,
   visibility TEXT NOT NULL DEFAULT 'family',
   telegram_bot_token TEXT,
+  signal_account TEXT,
+  signal_daemon_port INTEGER,
   model TEXT NOT NULL DEFAULT 'claude-sonnet-4-6',
   status TEXT NOT NULL DEFAULT 'active',
   is_head_butler INTEGER NOT NULL DEFAULT 0,
@@ -239,6 +242,29 @@ CREATE TABLE tool_grants (
 CREATE INDEX tool_grants_agent_idx ON tool_grants(agent_id);
 CREATE UNIQUE INDEX tool_grants_unique ON tool_grants(agent_id, tool_name);
 
+CREATE TABLE scheduled_tasks (
+  id TEXT PRIMARY KEY,
+  household_id TEXT NOT NULL REFERENCES households(id),
+  agent_id TEXT NOT NULL REFERENCES staff_agents(id),
+  member_id TEXT REFERENCES family_members(id),
+  name TEXT NOT NULL,
+  prompt TEXT NOT NULL,
+  schedule_type TEXT NOT NULL,
+  schedule_value TEXT NOT NULL,
+  timezone TEXT NOT NULL DEFAULT 'America/New_York',
+  enabled INTEGER NOT NULL DEFAULT 1,
+  last_run_at INTEGER,
+  next_run_at INTEGER,
+  last_status TEXT,
+  last_error TEXT,
+  run_count INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+CREATE INDEX scheduled_tasks_household_idx ON scheduled_tasks(household_id);
+CREATE INDEX scheduled_tasks_agent_idx ON scheduled_tasks(agent_id);
+CREATE INDEX scheduled_tasks_next_run_idx ON scheduled_tasks(next_run_at);
+
 CREATE TABLE instance_settings (
   id TEXT PRIMARY KEY,
   key TEXT NOT NULL UNIQUE,
@@ -292,7 +318,7 @@ CREATE UNIQUE INDEX tool_secrets_household_key_unique ON tool_secrets(household_
   });
 
   transaction();
-  console.log("[db] Tables created (v4 schema — 15 tables, delegation support)");
+  console.log("[db] Tables created (v4 schema — 16 tables, delegation support)");
 }
 
 /** Upgrade existing v3 DB to v4 schema */
@@ -319,8 +345,10 @@ function upgradeTables(sqlite: Database.Database, preMigrationHook?: PreMigratio
     (teCols.has("actor") && !teCols.has("agent_id")) ||
     !tableExists("delegation_edges") || !tableExists("profile_interview_state") ||
     !tableExists("tool_grants") || !tableExists("personality_interview_state") ||
+    !tableExists("scheduled_tasks") ||
+    !staffCols.has("signal_account") || !staffCols.has("signal_daemon_port") ||
     !memberCols.has("profile_content") || !memberCols.has("profile_updated_at") ||
-    !memberCols.has("memory_dir");
+    !memberCols.has("memory_dir") || !memberCols.has("signal_number");
 
   if (needsUpgrade && preMigrationHook) {
     preMigrationHook("schema-upgrade");
@@ -535,8 +563,24 @@ function upgradeTables(sqlite: Database.Database, preMigrationHook?: PreMigratio
       upgraded = true;
     }
 
+    // staff_agents: add Signal transport columns
+    if (!staffCols.has("signal_account")) {
+      sqlite.prepare("ALTER TABLE staff_agents ADD COLUMN signal_account TEXT").run();
+      upgraded = true;
+    }
+    if (!staffCols.has("signal_daemon_port")) {
+      sqlite.prepare("ALTER TABLE staff_agents ADD COLUMN signal_daemon_port INTEGER").run();
+      upgraded = true;
+    }
+
+    // family_members: add Signal number
+    if (!memberCols.has("signal_number")) {
+      sqlite.prepare("ALTER TABLE family_members ADD COLUMN signal_number TEXT").run();
+      upgraded = true;
+    }
+
     if (upgraded) {
-      console.log("[db] Schema upgraded (v10 — custom tool registry)");
+      console.log("[db] Schema upgraded (v10 — custom tool registry + Signal transport)");
     }
   });
 

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -47,6 +47,7 @@ CREATE TABLE family_members (
   age INTEGER NOT NULL,
   telegram_user_id TEXT UNIQUE,
   signal_number TEXT UNIQUE,
+  signal_uuid TEXT UNIQUE,
   profile_content TEXT,
   profile_updated_at INTEGER,
   memory_dir TEXT,
@@ -348,7 +349,8 @@ function upgradeTables(sqlite: Database.Database, preMigrationHook?: PreMigratio
     !tableExists("scheduled_tasks") ||
     !staffCols.has("signal_account") || !staffCols.has("signal_daemon_port") ||
     !memberCols.has("profile_content") || !memberCols.has("profile_updated_at") ||
-    !memberCols.has("memory_dir") || !memberCols.has("signal_number");
+    !memberCols.has("memory_dir") || !memberCols.has("signal_number") ||
+    !memberCols.has("signal_uuid");
 
   if (needsUpgrade && preMigrationHook) {
     preMigrationHook("schema-upgrade");
@@ -576,6 +578,13 @@ function upgradeTables(sqlite: Database.Database, preMigrationHook?: PreMigratio
     // family_members: add Signal number
     if (!memberCols.has("signal_number")) {
       sqlite.prepare("ALTER TABLE family_members ADD COLUMN signal_number TEXT").run();
+      upgraded = true;
+    }
+
+    // family_members: add Signal UUID (ACI) — used when sender's phone
+    // privacy prevents sourceNumber from appearing in the envelope
+    if (!memberCols.has("signal_uuid")) {
+      sqlite.prepare("ALTER TABLE family_members ADD COLUMN signal_uuid TEXT").run();
       upgraded = true;
     }
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -31,6 +31,7 @@ export const familyMembers = sqliteTable(
     age: integer("age").notNull(),
     telegramUserId: text("telegram_user_id").unique(),
     signalNumber: text("signal_number").unique(), // Signal phone number (e.g. +15551234567)
+    signalUuid: text("signal_uuid").unique(), // Signal ACI (sender UUID) — used when phone sharing is off
     profileContent: text("profile_content"), // Per-person profile document (member.md)
     profileUpdatedAt: integer("profile_updated_at", { mode: "timestamp" }),
     memoryDir: text("memory_dir"), // Override: point at existing brain directory instead of default

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -30,6 +30,7 @@ export const familyMembers = sqliteTable(
     role: text("role").notNull(), // parent | student | child
     age: integer("age").notNull(),
     telegramUserId: text("telegram_user_id").unique(),
+    signalNumber: text("signal_number").unique(), // Signal phone number (e.g. +15551234567)
     profileContent: text("profile_content"), // Per-person profile document (member.md)
     profileUpdatedAt: integer("profile_updated_at", { mode: "timestamp" }),
     memoryDir: text("memory_dir"), // Override: point at existing brain directory instead of default
@@ -56,6 +57,8 @@ export const staffAgents = sqliteTable(
     soulContent: text("soul_content"), // Personality: voice, tone, values. NULL for internal agents.
     visibility: text("visibility").notNull().default("family"), // family | internal
     telegramBotToken: text("telegram_bot_token"), // Bot token for family-visible agents. NULL for internal.
+    signalAccount: text("signal_account"), // Signal phone number the agent's daemon is registered under
+    signalDaemonPort: integer("signal_daemon_port"), // signal-cli daemon HTTP port
     model: text("model").notNull().default("claude-sonnet-4-6"),
     status: text("status").notNull().default("active"), // active | paused | idle
     isHeadButler: integer("is_head_butler", { mode: "boolean" }).notNull().default(false),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -61,7 +61,7 @@ export type TaskEventType =
 
 export type MessageRole = "user" | "assistant" | "system";
 
-export type Channel = "telegram" | "web" | "scheduled";
+export type Channel = "telegram" | "web" | "scheduled" | "signal";
 
 export type OnboardingPhase = "interview" | "review" | "staff_setup" | "telegram_config" | "complete";
 

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -6,12 +6,13 @@ set -euo pipefail
 # macOS: launchd (~/Library/LaunchAgents)
 # Linux: systemd user service (~/.config/systemd/user)
 #
-# Runs the server in the background, starts on login, restarts on crash.
+# Runs the CarsonOS server and signal-cli daemon in the background,
+# both start on login and restart on crash.
 #
 # Usage:
-#   ./scripts/install-service.sh          # install and start
-#   ./scripts/install-service.sh --stop   # stop the service
-#   ./scripts/install-service.sh --uninstall  # remove the service
+#   ./scripts/install-service.sh          # install and start both services
+#   ./scripts/install-service.sh --stop   # stop both services
+#   ./scripts/install-service.sh --uninstall  # remove both services
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -22,51 +23,87 @@ PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 LOG_DIR="$HOME/.carsonos/logs"
 PLATFORM="$(uname)"
 
+# ── signal-cli config ────────────────────────────────────────────
+# SIGNAL_NUMBER must be set in the environment (E.164 format, e.g. +1XXXXXXXXXX).
+# SIGNAL_PORT defaults to 8080 but can be overridden.
+SIGNAL_NUMBER="${SIGNAL_NUMBER:-}"
+SIGNAL_PORT="${SIGNAL_PORT:-8080}"
+
 # ── Platform detection ───────────────────────────────────────────
 
 if [[ "$PLATFORM" == "Darwin" ]]; then
   SERVICE_TYPE="launchd"
   PLIST_NAME="com.carsonos.server"
   PLIST_PATH="$HOME/Library/LaunchAgents/${PLIST_NAME}.plist"
+  SIGNAL_PLIST_NAME="com.carsonos.signal-cli"
+  SIGNAL_PLIST_PATH="$HOME/Library/LaunchAgents/${SIGNAL_PLIST_NAME}.plist"
 elif command -v systemctl &>/dev/null; then
   SERVICE_TYPE="systemd"
   SYSTEMD_NAME="carsonos"
   SYSTEMD_DIR="$HOME/.config/systemd/user"
   SYSTEMD_PATH="${SYSTEMD_DIR}/${SYSTEMD_NAME}.service"
+  SIGNAL_SYSTEMD_NAME="carsonos-signal-cli"
+  SIGNAL_SYSTEMD_PATH="${SYSTEMD_DIR}/${SIGNAL_SYSTEMD_NAME}.service"
 else
   SERVICE_TYPE="none"
 fi
 
 # ── Service commands ─────────────────────────────────────────────
 
-stop_service() {
+stop_signal_service() {
+  if [[ "$SERVICE_TYPE" == "launchd" ]]; then
+    if launchctl list "$SIGNAL_PLIST_NAME" &>/dev/null; then
+      launchctl bootout "gui/$(id -u)/$SIGNAL_PLIST_NAME" 2>/dev/null || true
+      echo -e "  ${GREEN}✓${NC} signal-cli stopped (launchd)"
+    else
+      echo -e "  ${YELLOW}○${NC} signal-cli was not running"
+    fi
+  elif [[ "$SERVICE_TYPE" == "systemd" ]]; then
+    if systemctl --user is-active "$SIGNAL_SYSTEMD_NAME" &>/dev/null; then
+      systemctl --user stop "$SIGNAL_SYSTEMD_NAME"
+      echo -e "  ${GREEN}✓${NC} signal-cli stopped (systemd)"
+    else
+      echo -e "  ${YELLOW}○${NC} signal-cli was not running"
+    fi
+  fi
+}
+
+stop_carsonos_service() {
   if [[ "$SERVICE_TYPE" == "launchd" ]]; then
     if launchctl list "$PLIST_NAME" &>/dev/null; then
       launchctl bootout "gui/$(id -u)/$PLIST_NAME" 2>/dev/null || true
-      echo -e "  ${GREEN}✓${NC} Service stopped (launchd)"
+      echo -e "  ${GREEN}✓${NC} CarsonOS stopped (launchd)"
     else
-      echo -e "  ${YELLOW}○${NC} Service was not running"
+      echo -e "  ${YELLOW}○${NC} CarsonOS was not running"
     fi
   elif [[ "$SERVICE_TYPE" == "systemd" ]]; then
     if systemctl --user is-active "$SYSTEMD_NAME" &>/dev/null; then
       systemctl --user stop "$SYSTEMD_NAME"
-      echo -e "  ${GREEN}✓${NC} Service stopped (systemd)"
+      echo -e "  ${GREEN}✓${NC} CarsonOS stopped (systemd)"
     else
-      echo -e "  ${YELLOW}○${NC} Service was not running"
+      echo -e "  ${YELLOW}○${NC} CarsonOS was not running"
     fi
   fi
+}
+
+stop_service() {
+  stop_carsonos_service
+  stop_signal_service
 }
 
 uninstall_service() {
   stop_service
   if [[ "$SERVICE_TYPE" == "launchd" ]]; then
     rm -f "$PLIST_PATH"
+    rm -f "$SIGNAL_PLIST_PATH"
   elif [[ "$SERVICE_TYPE" == "systemd" ]]; then
     systemctl --user disable "$SYSTEMD_NAME" 2>/dev/null || true
+    systemctl --user disable "$SIGNAL_SYSTEMD_NAME" 2>/dev/null || true
     rm -f "$SYSTEMD_PATH"
+    rm -f "$SIGNAL_SYSTEMD_PATH"
     systemctl --user daemon-reload
   fi
-  echo -e "  ${GREEN}✓${NC} Service removed"
+  echo -e "  ${GREEN}✓${NC} All services removed"
   exit 0
 }
 
@@ -103,16 +140,37 @@ if ! command -v pnpm &>/dev/null; then
   exit 1
 fi
 
+SIGNAL_CLI_PATH="$(command -v signal-cli 2>/dev/null || echo '')"
+if [[ -z "$SIGNAL_CLI_PATH" ]]; then
+  echo -e "  ${YELLOW}⚠${NC}  signal-cli not found in PATH — skipping Signal service install"
+  echo "     Install signal-cli and re-run to enable Signal transport."
+  INSTALL_SIGNAL=false
+elif [[ -z "$SIGNAL_NUMBER" ]]; then
+  echo -e "${RED}Error:${NC} SIGNAL_NUMBER is not set."
+  echo ""
+  echo "  signal-cli was found but no phone number is configured."
+  echo "  Set SIGNAL_NUMBER in your environment (E.164 format) and re-run:"
+  echo ""
+  echo "    SIGNAL_NUMBER=+1XXXXXXXXXX ./scripts/install-service.sh"
+  echo ""
+  exit 1
+else
+  INSTALL_SIGNAL=true
+fi
+
 # ── Install ──────────────────────────────────────────────────────
 
 echo ""
-echo "  Installing CarsonOS service"
-echo "  ==========================="
+echo "  Installing CarsonOS services"
+echo "  ============================"
 echo ""
-echo "  Platform: $SERVICE_TYPE"
-echo "  Project:  $PROJECT_DIR"
-echo "  Data:     $HOME/.carsonos"
-echo "  Logs:     $LOG_DIR"
+echo "  Platform:    $SERVICE_TYPE"
+echo "  Project:     $PROJECT_DIR"
+echo "  Data:        $HOME/.carsonos"
+echo "  Logs:        $LOG_DIR"
+if $INSTALL_SIGNAL; then
+  echo "  signal-cli:  $SIGNAL_CLI_PATH ($SIGNAL_NUMBER → port $SIGNAL_PORT)"
+fi
 echo ""
 
 # Ensure deps are installed
@@ -130,6 +188,53 @@ if [[ "$SERVICE_TYPE" == "launchd" ]]; then
 
   mkdir -p "$(dirname "$PLIST_PATH")"
 
+  # signal-cli daemon (install first so it's up before CarsonOS starts)
+  if $INSTALL_SIGNAL; then
+    cat > "$SIGNAL_PLIST_PATH" << PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${SIGNAL_PLIST_NAME}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${SIGNAL_CLI_PATH}</string>
+    <string>-a</string>
+    <string>${SIGNAL_NUMBER}</string>
+    <string>daemon</string>
+    <string>--http</string>
+    <string>localhost:${SIGNAL_PORT}</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>${HOME}</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>${LOG_DIR}/signal-cli-stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>${LOG_DIR}/signal-cli-stderr.log</string>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+</dict>
+</plist>
+PLIST
+
+    echo -e "  ${GREEN}✓${NC} Created $SIGNAL_PLIST_PATH"
+    stop_signal_service
+    launchctl bootstrap "gui/$(id -u)" "$SIGNAL_PLIST_PATH"
+    echo -e "  ${GREEN}✓${NC} signal-cli started"
+  fi
+
+  # CarsonOS server
   cat > "$PLIST_PATH" << PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -173,19 +278,50 @@ if [[ "$SERVICE_TYPE" == "launchd" ]]; then
 PLIST
 
   echo -e "  ${GREEN}✓${NC} Created $PLIST_PATH"
-  stop_service
-  launchctl bootstrap "gui/$(id -u)" "$PLIST_PATH"
-  echo -e "  ${GREEN}✓${NC} Service started"
+  stop_carsonos_service
+  # launchd can take a moment to fully deregister after bootout — retry once on error 5
+  launchctl bootstrap "gui/$(id -u)" "$PLIST_PATH" 2>/dev/null || \
+    { sleep 2; launchctl bootstrap "gui/$(id -u)" "$PLIST_PATH"; }
+  echo -e "  ${GREEN}✓${NC} CarsonOS started"
 
 elif [[ "$SERVICE_TYPE" == "systemd" ]]; then
   # ── Linux systemd ────────────────────────────────────────────
 
   mkdir -p "$SYSTEMD_DIR"
 
+  # signal-cli daemon
+  if $INSTALL_SIGNAL; then
+    cat > "$SIGNAL_SYSTEMD_PATH" << UNIT
+[Unit]
+Description=signal-cli daemon for CarsonOS
+After=network.target
+
+[Service]
+Type=simple
+Environment=HOME=${HOME}
+ExecStart=${SIGNAL_CLI_PATH} -a ${SIGNAL_NUMBER} daemon --http localhost:${SIGNAL_PORT}
+Restart=on-failure
+RestartSec=10
+StandardOutput=append:${LOG_DIR}/signal-cli-stdout.log
+StandardError=append:${LOG_DIR}/signal-cli-stderr.log
+
+[Install]
+WantedBy=default.target
+UNIT
+
+    echo -e "  ${GREEN}✓${NC} Created $SIGNAL_SYSTEMD_PATH"
+    systemctl --user daemon-reload
+    systemctl --user enable "$SIGNAL_SYSTEMD_NAME"
+    stop_signal_service
+    systemctl --user start "$SIGNAL_SYSTEMD_NAME"
+    echo -e "  ${GREEN}✓${NC} signal-cli started and enabled on login"
+  fi
+
+  # CarsonOS server
   cat > "$SYSTEMD_PATH" << UNIT
 [Unit]
 Description=CarsonOS — Family AI Agent Platform
-After=network.target
+After=network.target${INSTALL_SIGNAL:+ $SIGNAL_SYSTEMD_NAME.service}
 
 [Service]
 Type=simple
@@ -207,34 +343,49 @@ UNIT
   echo -e "  ${GREEN}✓${NC} Created $SYSTEMD_PATH"
   systemctl --user daemon-reload
   systemctl --user enable "$SYSTEMD_NAME"
-  stop_service
+  stop_carsonos_service
   systemctl --user start "$SYSTEMD_NAME"
-  echo -e "  ${GREEN}✓${NC} Service started and enabled on login"
+  echo -e "  ${GREEN}✓${NC} CarsonOS started and enabled on login"
 fi
 
 # ── Verify ───────────────────────────────────────────────────────
 
 sleep 2
 RUNNING=false
-if [[ "$SERVICE_TYPE" == "launchd" ]] && launchctl list "$PLIST_NAME" &>/dev/null; then
-  RUNNING=true
-elif [[ "$SERVICE_TYPE" == "systemd" ]] && systemctl --user is-active "$SYSTEMD_NAME" &>/dev/null; then
-  RUNNING=true
+SIGNAL_RUNNING=false
+
+if [[ "$SERVICE_TYPE" == "launchd" ]]; then
+  launchctl list "$PLIST_NAME" &>/dev/null && RUNNING=true
+  $INSTALL_SIGNAL && launchctl list "$SIGNAL_PLIST_NAME" &>/dev/null && SIGNAL_RUNNING=true
+elif [[ "$SERVICE_TYPE" == "systemd" ]]; then
+  systemctl --user is-active "$SYSTEMD_NAME" &>/dev/null && RUNNING=true
+  $INSTALL_SIGNAL && systemctl --user is-active "$SIGNAL_SYSTEMD_NAME" &>/dev/null && SIGNAL_RUNNING=true
 fi
 
+echo ""
 if $RUNNING; then
-  echo ""
   echo -e "  ${GREEN}CarsonOS is running!${NC}"
-  echo ""
-  echo "  Dashboard:  http://localhost:3300"
-  echo "  Logs:       tail -f $LOG_DIR/stdout.log"
-  echo "  Restart:    pnpm restart"
-  echo "  Stop:       ./scripts/install-service.sh --stop"
-  echo "  Uninstall:  ./scripts/install-service.sh --uninstall"
-  echo ""
 else
-  echo ""
-  echo -e "  ${RED}Service may not have started. Check logs:${NC}"
+  echo -e "  ${RED}CarsonOS may not have started. Check logs:${NC}"
   echo "  tail -20 $LOG_DIR/stderr.log"
-  echo ""
 fi
+
+if $INSTALL_SIGNAL; then
+  if $SIGNAL_RUNNING; then
+    echo -e "  ${GREEN}signal-cli is running!${NC}"
+  else
+    echo -e "  ${RED}signal-cli may not have started. Check logs:${NC}"
+    echo "  tail -20 $LOG_DIR/signal-cli-stderr.log"
+  fi
+fi
+
+echo ""
+echo "  Dashboard:  http://localhost:3300"
+echo "  Logs:       tail -f $LOG_DIR/stdout.log"
+if $INSTALL_SIGNAL; then
+  echo "  Signal:     tail -f $LOG_DIR/signal-cli-stdout.log"
+fi
+echo "  Restart:    pnpm restart"
+echo "  Stop:       ./scripts/install-service.sh --stop"
+echo "  Uninstall:  ./scripts/install-service.sh --uninstall"
+echo ""

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -25,6 +25,7 @@ import type { ProfileInterviewEngine } from "./services/profile-interview.js";
 import type { PersonalityInterviewEngine } from "./services/personality-interview.js";
 import type { ToolRegistry } from "./services/tool-registry.js";
 import type { MultiRelayManager } from "./services/multi-relay-manager.js";
+import type { SignalRelayManager } from "./services/signal-relay-manager.js";
 
 import { createHealthRoutes } from "./routes/health.js";
 import { createHouseholdRoutes } from "./routes/households.js";
@@ -53,6 +54,7 @@ export interface AppDeps {
   personalityInterviewEngine: PersonalityInterviewEngine;
   toolRegistry: ToolRegistry;
   multiRelay?: MultiRelayManager;
+  signalRelay?: SignalRelayManager;
 }
 
 export async function createApp(deps: AppDeps): Promise<express.Express> {
@@ -92,7 +94,7 @@ export async function createApp(deps: AppDeps): Promise<express.Express> {
   app.use("/api/health", createHealthRoutes({ adapter }));
   app.use("/api/households", createHouseholdRoutes(db));
   app.use("/api/households", createMemberRoutes(db));
-  app.use("/api/staff", createStaffRoutes({ db, personalityInterviewEngine, multiRelay: deps.multiRelay }));
+  app.use("/api/staff", createStaffRoutes({ db, personalityInterviewEngine, multiRelay: deps.multiRelay, signalRelay: deps.signalRelay }));
   app.use("/api/tasks", createTaskRoutes({ db, taskEngine, oversight }));
   app.use(
     "/api/constitution",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -36,6 +36,7 @@ import { PersonalityInterviewEngine } from "./services/personality-interview.js"
 import { Dispatcher } from "./services/dispatcher.js";
 import { DelegationOrchestrator } from "./services/delegation-orchestrator.js";
 import { MultiRelayManager } from "./services/multi-relay-manager.js";
+import { SignalRelayManager } from "./services/signal-relay-manager.js";
 import { bootMemory } from "./services/memory/index.js";
 import { hydrateEnvFromSettings } from "./services/env-hydration.js";
 import { ToolRegistry } from "./services/tool-registry.js";
@@ -237,6 +238,13 @@ async function main() {
   // Wire multiRelay into the constitution engine (for agent pause/resume tools)
   constitutionEngine.setMultiRelay(multiRelay);
 
+  // 7b. Signal relay (agents with signal_account + signal_daemon_port set)
+  const signalRelay = new SignalRelayManager({
+    db,
+    engine: constitutionEngine,
+    orchestrator,
+  });
+
   // 8. Create Express app with all dependencies
   const app = await createApp({
     db,
@@ -249,6 +257,7 @@ async function main() {
     personalityInterviewEngine,
     toolRegistry,
     multiRelay,
+    signalRelay,
   });
 
   // 9. Create HTTP server and attach WebSocket
@@ -268,10 +277,13 @@ async function main() {
   eventBus.on("delegation.result", (event) => {
     if (!event.data) return;
     multiRelay.eventBus.emit("delegation.result", event.data);
+    signalRelay.eventBus.emit("delegation.result", event.data);
   });
 
   // Start per-agent bots (agents with telegramBotToken set)
   await multiRelay.startAll();
+  // Start per-agent Signal accounts (agents with signal_account + signal_daemon_port set)
+  await signalRelay.startAll();
 
   // 11. Start the scheduled task ticker
   const scheduler = new Scheduler({
@@ -331,7 +343,7 @@ async function main() {
 
     void (async () => {
       try {
-        await multiRelay.stopAll();
+        await Promise.all([multiRelay.stopAll(), signalRelay.stopAll()]);
       } catch (err) {
         console.error("[shutdown] relay stop error:", err);
       }

--- a/server/src/routes/members.ts
+++ b/server/src/routes/members.ts
@@ -26,7 +26,7 @@ export function createMemberRoutes(db: Db): Router {
 
   // POST /:householdId/members -- create member
   router.post("/:householdId/members", async (req, res) => {
-    const { name, role, age, telegramUserId, memoryDir } = req.body;
+    const { name, role, age, telegramUserId, memoryDir, signalNumber, signalUuid } = req.body;
     const { householdId } = req.params;
 
     if (!name || !role || age === undefined) {
@@ -51,6 +51,8 @@ export function createMemberRoutes(db: Db): Router {
           role,
           age,
           telegramUserId: telegramUserId ?? null,
+          signalNumber: signalNumber ?? null,
+          signalUuid: signalUuid ?? null,
           memoryDir: memoryDir ?? null,
         })
         .returning();
@@ -59,7 +61,7 @@ export function createMemberRoutes(db: Db): Router {
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes("UNIQUE constraint")) {
-        res.status(409).json({ error: "That Telegram ID is already assigned to another member." });
+        res.status(409).json({ error: "That Telegram ID, Signal number, or Signal UUID is already assigned to another member." });
       } else {
         throw err;
       }
@@ -68,7 +70,7 @@ export function createMemberRoutes(db: Db): Router {
 
   // PUT /:householdId/members/:id -- update member
   router.put("/:householdId/members/:id", async (req, res) => {
-    const { name, role, age, telegramUserId, memoryDir } = req.body;
+    const { name, role, age, telegramUserId, memoryDir, signalNumber, signalUuid } = req.body;
 
     const existing = await db
       .select()
@@ -86,19 +88,30 @@ export function createMemberRoutes(db: Db): Router {
       return;
     }
 
-    const [updated] = await db
-      .update(familyMembers)
-      .set({
-        ...(name !== undefined && { name }),
-        ...(role !== undefined && { role }),
-        ...(age !== undefined && { age }),
-        ...(telegramUserId !== undefined && { telegramUserId }),
-        ...(memoryDir !== undefined && { memoryDir }),
-      })
-      .where(eq(familyMembers.id, req.params.id))
-      .returning();
+    try {
+      const [updated] = await db
+        .update(familyMembers)
+        .set({
+          ...(name !== undefined && { name }),
+          ...(role !== undefined && { role }),
+          ...(age !== undefined && { age }),
+          ...(telegramUserId !== undefined && { telegramUserId }),
+          ...(signalNumber !== undefined && { signalNumber }),
+          ...(signalUuid !== undefined && { signalUuid }),
+          ...(memoryDir !== undefined && { memoryDir }),
+        })
+        .where(eq(familyMembers.id, req.params.id))
+        .returning();
 
-    res.json({ member: updated });
+      res.json({ member: updated });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("UNIQUE constraint")) {
+        res.status(409).json({ error: "That Telegram ID, Signal number, or Signal UUID is already assigned to another member." });
+      } else {
+        throw err;
+      }
+    }
   });
 
   // DELETE /:householdId/members/:id -- delete member

--- a/server/src/routes/staff.ts
+++ b/server/src/routes/staff.ts
@@ -19,15 +19,17 @@ import {
 } from "@carsonos/db";
 import type { PersonalityInterviewEngine } from "../services/personality-interview.js";
 import type { MultiRelayManager } from "../services/multi-relay-manager.js";
+import type { SignalRelayManager } from "../services/signal-relay-manager.js";
 
 export interface StaffRouteDeps {
   db: Db;
   personalityInterviewEngine: PersonalityInterviewEngine;
   multiRelay?: MultiRelayManager;
+  signalRelay?: SignalRelayManager;
 }
 
 export function createStaffRoutes(deps: StaffRouteDeps): Router {
-  const { db, personalityInterviewEngine, multiRelay } = deps;
+  const { db, personalityInterviewEngine, multiRelay, signalRelay } = deps;
   const router = Router();
 
   // GET / -- list all staff agents (scoped to household)
@@ -183,6 +185,13 @@ export function createStaffRoutes(deps: StaffRouteDeps): Router {
       });
     }
 
+    // If created with a Signal account, start the Signal relay immediately
+    if (req.body.signal_account && signalRelay) {
+      signalRelay.startAccount(agent.id).catch((err) => {
+        console.error(`[staff] Failed to start Signal relay for new agent:`, err);
+      });
+    }
+
     res.status(201).json({ agent });
   });
 
@@ -234,6 +243,13 @@ export function createStaffRoutes(deps: StaffRouteDeps): Router {
     if (telegramBotToken && multiRelay) {
       multiRelay.startBot(req.params.id).catch((err) => {
         console.error(`[staff] Failed to start bot after token update:`, err);
+      });
+    }
+
+    // If Signal account was added or changed, start/restart the Signal relay
+    if (req.body.signal_account && signalRelay) {
+      signalRelay.startAccount(req.params.id).catch((err) => {
+        console.error(`[staff] Failed to start Signal relay after account update:`, err);
       });
     }
 

--- a/server/src/routes/staff.ts
+++ b/server/src/routes/staff.ts
@@ -171,6 +171,8 @@ export function createStaffRoutes(deps: StaffRouteDeps): Router {
         soulContent: soulContent ?? null,
         visibility: visibility ?? "family",
         telegramBotToken: telegramBotToken ?? null,
+        signalAccount: req.body.signal_account ?? null,
+        signalDaemonPort: req.body.signal_daemon_port ?? null,
         model: model ?? "claude-sonnet-4-6",
         trustLevel: trustLevel ?? "restricted",
         isHeadButler: isHeadButler ?? false,
@@ -221,6 +223,9 @@ export function createStaffRoutes(deps: StaffRouteDeps): Router {
       autonomyLevel,
     } = req.body;
 
+    const signalAccount = req.body.signal_account;
+    const signalDaemonPort = req.body.signal_daemon_port;
+
     const [updated] = await db
       .update(staffAgents)
       .set({
@@ -231,6 +236,8 @@ export function createStaffRoutes(deps: StaffRouteDeps): Router {
         ...(soulContent !== undefined && { soulContent }),
         ...(visibility !== undefined && { visibility }),
         ...(telegramBotToken !== undefined && { telegramBotToken }),
+        ...(signalAccount !== undefined && { signalAccount }),
+        ...(signalDaemonPort !== undefined && { signalDaemonPort }),
         ...(model !== undefined && { model }),
         ...(status !== undefined && { status }),
         ...(autonomyLevel !== undefined && { autonomyLevel }),
@@ -247,7 +254,7 @@ export function createStaffRoutes(deps: StaffRouteDeps): Router {
     }
 
     // If Signal account was added or changed, start/restart the Signal relay
-    if (req.body.signal_account && signalRelay) {
+    if (signalAccount && signalRelay) {
       signalRelay.startAccount(req.params.id).catch((err) => {
         console.error(`[staff] Failed to start Signal relay after account update:`, err);
       });

--- a/server/src/services/__tests__/signal-streaming.test.ts
+++ b/server/src/services/__tests__/signal-streaming.test.ts
@@ -1,0 +1,415 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  markdownToSignalText,
+  chunkSignalMessage,
+  createSignalStream,
+} from "../signal-streaming.js";
+
+describe("markdownToSignalText", () => {
+  it("strips bold markers", () => {
+    expect(markdownToSignalText("**bold** text")).toBe("bold text");
+    expect(markdownToSignalText("__also bold__ here")).toBe("also bold here");
+  });
+
+  it("strips italic markers", () => {
+    expect(markdownToSignalText("*italic* text")).toBe("italic text");
+    expect(markdownToSignalText("_also italic_ here")).toBe("also italic here");
+  });
+
+  it("strips strikethrough markers", () => {
+    expect(markdownToSignalText("~~struck~~ out")).toBe("struck out");
+  });
+
+  it("strips inline code backticks while preserving content", () => {
+    expect(markdownToSignalText("run `pnpm test` now")).toBe("run pnpm test now");
+  });
+
+  it("preserves fenced code block content without fences", () => {
+    const input = "before\n```ts\nconst x = 1;\nconst y = 2;\n```\nafter";
+    const output = markdownToSignalText(input);
+    expect(output).toContain("const x = 1;");
+    expect(output).toContain("const y = 2;");
+    expect(output).not.toContain("```");
+  });
+
+  it("keeps fenced code content verbatim (does not strip markdown inside)", () => {
+    // Signal has no formatting, so contents still get processed — but the fence
+    // itself must go. Verify that fence markers are removed regardless of language tag.
+    const withLang = markdownToSignalText("```python\nprint('hi')\n```");
+    const withoutLang = markdownToSignalText("```\nplain\n```");
+    expect(withLang).not.toContain("```");
+    expect(withoutLang).not.toContain("```");
+    expect(withLang).toContain("print('hi')");
+    expect(withoutLang).toContain("plain");
+  });
+
+  it("drops empty fenced code blocks entirely", () => {
+    // Empty fence replaced with "" leaves "before\n\nafter" — the fence markers
+    // are gone but the paragraph separation remains. Content of the fence is
+    // what matters here, not exact whitespace.
+    const result = markdownToSignalText("before\n```\n\n```\nafter");
+    expect(result).not.toContain("```");
+    expect(result).toContain("before");
+    expect(result).toContain("after");
+  });
+
+  it("strips ATX headers but keeps header text", () => {
+    expect(markdownToSignalText("# Heading 1")).toBe("Heading 1");
+    expect(markdownToSignalText("### Heading 3")).toBe("Heading 3");
+    expect(markdownToSignalText("###### Heading 6")).toBe("Heading 6");
+  });
+
+  it("converts horizontal rules to unicode dash line", () => {
+    expect(markdownToSignalText("above\n---\nbelow")).toBe("above\n─────────────\nbelow");
+    expect(markdownToSignalText("above\n***\nbelow")).toBe("above\n─────────────\nbelow");
+  });
+
+  it("strips blockquote markers", () => {
+    expect(markdownToSignalText("> quoted line")).toBe("quoted line");
+    expect(markdownToSignalText("> line one\n> line two")).toBe("line one\nline two");
+  });
+
+  it("normalizes unordered list markers to bullet", () => {
+    expect(markdownToSignalText("- one\n- two")).toBe("• one\n• two");
+    expect(markdownToSignalText("* one\n* two")).toBe("• one\n• two");
+    expect(markdownToSignalText("+ one\n+ two")).toBe("• one\n• two");
+  });
+
+  it("preserves ordered list numbering", () => {
+    expect(markdownToSignalText("1. first\n2. second\n10. tenth")).toBe(
+      "1. first\n2. second\n10. tenth",
+    );
+  });
+
+  it("collapses 3+ consecutive newlines to 2", () => {
+    expect(markdownToSignalText("a\n\n\n\nb")).toBe("a\n\nb");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(markdownToSignalText("   \n\nhello\n\n   ")).toBe("hello");
+  });
+
+  it("handles mixed markdown in a realistic LLM response", () => {
+    const input = [
+      "# Summary",
+      "",
+      "Here's what I found:",
+      "",
+      "- **Important:** check `config.json`",
+      "- Also review *logs*",
+      "",
+      "```bash",
+      "pnpm test",
+      "```",
+      "",
+      "> Note: this is a blockquote",
+    ].join("\n");
+
+    const output = markdownToSignalText(input);
+
+    expect(output).not.toContain("**");
+    expect(output).not.toContain("*"); // italic stripped
+    expect(output).not.toContain("`");
+    expect(output).not.toContain("```");
+    expect(output).not.toContain("#");
+    expect(output).not.toContain(">");
+    expect(output).toContain("Summary");
+    expect(output).toContain("Important:");
+    expect(output).toContain("config.json");
+    expect(output).toContain("• ");
+    expect(output).toContain("pnpm test");
+    expect(output).toContain("Note: this is a blockquote");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(markdownToSignalText("")).toBe("");
+    expect(markdownToSignalText("   \n   ")).toBe("");
+  });
+
+  it("leaves plain text untouched (aside from trim)", () => {
+    expect(markdownToSignalText("Just a normal sentence.")).toBe(
+      "Just a normal sentence.",
+    );
+  });
+});
+
+describe("chunkSignalMessage", () => {
+  it("returns a single chunk for text under the limit", () => {
+    const text = "short message";
+    expect(chunkSignalMessage(text)).toEqual([text]);
+  });
+
+  it("returns a single chunk for text exactly at the limit", () => {
+    const text = "x".repeat(4000);
+    const chunks = chunkSignalMessage(text);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toHaveLength(4000);
+  });
+
+  it("splits on paragraph boundaries when possible", () => {
+    const para = "x".repeat(2500);
+    const text = `${para}\n\n${para}\n\n${para}`;
+    const chunks = chunkSignalMessage(text);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(c.length).toBeLessThanOrEqual(4000);
+    }
+  });
+
+  it("preserves paragraph separators within chunks", () => {
+    const small = "short para";
+    const text = `${small}\n\n${small}\n\n${small}`;
+    const chunks = chunkSignalMessage(text, 4000);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toContain("\n\n");
+  });
+
+  it("hard-splits a paragraph longer than maxChars on word boundary", () => {
+    const words = Array.from({ length: 500 }, (_, i) => `word${i}`).join(" ");
+    // words is ~3500 chars, force a 100-char limit to trigger hard-split
+    const chunks = chunkSignalMessage(words, 100);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(c.length).toBeLessThanOrEqual(100);
+      // Each chunk should either end mid-word at the limit, or end on a full word.
+      // Verify no chunk has leading/trailing whitespace from the split.
+      expect(c).toBe(c.trim());
+    }
+  });
+
+  it("falls back to hard-cut when no word boundary exists within the limit", () => {
+    const noSpaces = "x".repeat(300);
+    const chunks = chunkSignalMessage(noSpaces, 100);
+    expect(chunks).toHaveLength(3);
+    for (const c of chunks) {
+      expect(c.length).toBeLessThanOrEqual(100);
+    }
+    expect(chunks.join("")).toBe(noSpaces);
+  });
+
+  it("filters out empty chunks produced by paragraph splits", () => {
+    // Mix real content with empty paragraphs, forced into split mode by a tiny
+    // maxChars. Every returned chunk should contain non-whitespace text.
+    const text = "alpha\n\n\n\nbeta\n\n\n\ngamma";
+    const chunks = chunkSignalMessage(text, 6);
+    expect(chunks.length).toBeGreaterThan(0);
+    for (const c of chunks) {
+      expect(c.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("respects a custom maxChars argument", () => {
+    const text = "a".repeat(50);
+    const chunks = chunkSignalMessage(text, 20);
+    expect(chunks.every((c) => c.length <= 20)).toBe(true);
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("keeps ordering stable across paragraph splits", () => {
+    // Use paragraph markers that are both (a) distinct per paragraph so we can
+    // track order, and (b) each paragraph fits under maxChars so none require
+    // hard-splitting. That way chunks always preserve paragraph identity.
+    const markers = ["ALPHA", "BRAVO", "CHARLIE", "DELTA", "ECHO"];
+    const paragraphs = markers.map((m) => `${m} ${"x".repeat(1500)}`);
+    const text = paragraphs.join("\n\n");
+    const chunks = chunkSignalMessage(text, 4000);
+
+    expect(chunks.length).toBeGreaterThan(1);
+
+    const rejoined = chunks.join("\n\n");
+    for (const m of markers) {
+      expect(rejoined).toContain(m);
+    }
+    // Markers must appear in their original order.
+    for (let i = 0; i < markers.length - 1; i++) {
+      expect(rejoined.indexOf(markers[i])).toBeLessThan(rejoined.indexOf(markers[i + 1]));
+    }
+  });
+});
+
+describe("createSignalStream", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("accumulates deltas and sends formatted text once on finish", async () => {
+    const sendTyping = vi.fn(async (): Promise<void> => {});
+    const onComplete = vi.fn(async (_text: string): Promise<void> => {});
+    const stream = createSignalStream(sendTyping, onComplete);
+
+    stream.onDelta("Hello ");
+    stream.onDelta("**world**");
+    stream.onDelta("!");
+
+    const result = await stream.finish();
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith("Hello world!");
+    expect(result.text).toBe("Hello **world**!");
+  });
+
+  it("strips thinking blocks from accumulated text before sending", async () => {
+    const sendTyping = vi.fn(async (): Promise<void> => {});
+    const onComplete = vi.fn(async (_text: string): Promise<void> => {});
+    const stream = createSignalStream(sendTyping, onComplete);
+
+    stream.onDelta("<thinking>hidden reasoning</thinking>");
+    stream.onDelta("visible answer");
+    await stream.finish();
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    const sent = String(onComplete.mock.calls[0]?.[0] ?? "");
+    expect(sent).not.toContain("hidden reasoning");
+    expect(sent).toContain("visible answer");
+  });
+
+  it("starts typing indicator immediately at construction", () => {
+    // Changed from the old "start on first delta" behavior: users were
+    // seeing 5-15s of dead air before the indicator appeared because Claude
+    // in thinking mode produces no text until the end. Starting at
+    // construction gives immediate feedback that the message was received.
+    const sendTyping = vi.fn(async (): Promise<void> => {});
+    const onComplete = vi.fn(async (_text: string): Promise<void> => {});
+    createSignalStream(sendTyping, onComplete);
+
+    expect(sendTyping).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-trigger typing on each delta", () => {
+    const sendTyping = vi.fn(async (): Promise<void> => {});
+    const onComplete = vi.fn(async (_text: string): Promise<void> => {});
+    const stream = createSignalStream(sendTyping, onComplete);
+
+    // One call from construction. Deltas do not add more.
+    expect(sendTyping).toHaveBeenCalledTimes(1);
+    stream.onDelta("a");
+    stream.onDelta("b");
+    stream.onDelta("c");
+    expect(sendTyping).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes typing indicator on 4s interval while streaming", () => {
+    const sendTyping = vi.fn(async (): Promise<void> => {});
+    const onComplete = vi.fn(async (_text: string): Promise<void> => {});
+    createSignalStream(sendTyping, onComplete);
+
+    // Immediate call from construction.
+    expect(sendTyping).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(4_000);
+    expect(sendTyping).toHaveBeenCalledTimes(2);
+
+    vi.advanceTimersByTime(4_000);
+    expect(sendTyping).toHaveBeenCalledTimes(3);
+
+    vi.advanceTimersByTime(4_000);
+    expect(sendTyping).toHaveBeenCalledTimes(4);
+  });
+
+  it("stops the typing interval on finish()", async () => {
+    const sendTyping = vi.fn(async (): Promise<void> => {});
+    const onComplete = vi.fn(async (_text: string): Promise<void> => {});
+    const stream = createSignalStream(sendTyping, onComplete);
+
+    stream.onDelta("start");
+    vi.advanceTimersByTime(4_000);
+    expect(sendTyping).toHaveBeenCalledTimes(2);
+
+    await stream.finish();
+
+    // After finish(), no further typing calls even after long elapsed time.
+    vi.advanceTimersByTime(20_000);
+    expect(sendTyping).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores deltas that arrive after finish()", async () => {
+    const sendTyping = vi.fn(async (): Promise<void> => {});
+    const onComplete = vi.fn(async (_text: string): Promise<void> => {});
+    const stream = createSignalStream(sendTyping, onComplete);
+
+    stream.onDelta("before finish");
+    await stream.finish();
+
+    stream.onDelta("after finish — should be dropped");
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith("before finish");
+  });
+
+  it("swallows sendTyping errors so they do not abort the stream", async () => {
+    const sendTyping = vi.fn(async (): Promise<void> => {
+      throw new Error("signal typing endpoint down");
+    });
+    const onComplete = vi.fn(async (_text: string): Promise<void> => {});
+    const stream = createSignalStream(sendTyping, onComplete);
+
+    // Must not throw even though sendTyping rejects.
+    stream.onDelta("first");
+    stream.onDelta("second");
+    await vi.advanceTimersByTimeAsync(4_000);
+
+    // finish() must still send the accumulated text normally.
+    await expect(stream.finish()).resolves.toEqual({ text: "firstsecond" });
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith("firstsecond");
+  });
+
+  it("does not call onComplete when the accumulated text is empty", async () => {
+    const sendTyping = vi.fn(async (): Promise<void> => {});
+    const onComplete = vi.fn(async (_text: string): Promise<void> => {});
+    const stream = createSignalStream(sendTyping, onComplete);
+
+    // No deltas before finish.
+    const result = await stream.finish();
+
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(result.text).toBe("");
+  });
+
+  it("does not call onComplete when only thinking blocks were accumulated", async () => {
+    const sendTyping = vi.fn(async (): Promise<void> => {});
+    const onComplete = vi.fn(async (_text: string): Promise<void> => {});
+    const stream = createSignalStream(sendTyping, onComplete);
+
+    stream.onDelta("<thinking>just reasoning, no answer</thinking>");
+    await stream.finish();
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("catches onComplete errors so finish() still resolves", async () => {
+    const sendTyping = vi.fn(async (): Promise<void> => {});
+    const onComplete = vi.fn(async (_text: string): Promise<void> => {
+      throw new Error("signal send failed");
+    });
+    const stream = createSignalStream(sendTyping, onComplete);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    stream.onDelta("hello");
+
+    await expect(stream.finish()).resolves.toEqual({ text: "hello" });
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    const errorLogCall = consoleErrorSpy.mock.calls[0] ?? [];
+    expect(String(errorLogCall[0] ?? "")).toContain("Failed to deliver");
+  });
+
+  it("returns raw accumulated text in result, not the formatted version", async () => {
+    const sendTyping = vi.fn(async (): Promise<void> => {});
+    const onComplete = vi.fn(async (_text: string): Promise<void> => {});
+    const stream = createSignalStream(sendTyping, onComplete);
+
+    stream.onDelta("**bold** text");
+    const result = await stream.finish();
+
+    // The formatted version (markdown stripped) went to onComplete.
+    expect(onComplete).toHaveBeenCalledWith("bold text");
+    // The raw accumulated version is returned — callers that want to log the
+    // model output can see what was actually produced.
+    expect(result.text).toBe("**bold** text");
+  });
+});

--- a/server/src/services/signal-relay-manager.ts
+++ b/server/src/services/signal-relay-manager.ts
@@ -1,0 +1,923 @@
+/**
+ * Signal Relay Manager — one signal-cli daemon connection per agent.
+ *
+ * Mirrors MultiRelayManager but uses signal-cli in HTTP JSON-RPC daemon
+ * mode as the transport instead of grammy/Telegram long-polling.
+ *
+ * Each family-visible agent with a configured Signal account gets its own
+ * daemon connection. Incoming messages are received via a persistent SSE
+ * connection to http://127.0.0.1:<port>/api/v1/events, which signal-cli uses
+ * to push envelopes as they arrive — zero polling latency. Outbound sends
+ * use the HTTP JSON-RPC endpoint at /api/v1/rpc. Automatic reconnection
+ * with exponential backoff handles daemon restarts.
+ *
+ * ── signal-cli daemon setup (run once per account, before CarsonOS) ──
+ *
+ *   # Register (first time only — follow the interactive prompts):
+ *   signal-cli -a +12025551234 register
+ *   signal-cli -a +12025551234 verify <code>
+ *
+ *   # Link as secondary device to an existing Signal account:
+ *   signal-cli link -n "Diakonos"
+ *
+ *   # Start daemon on a chosen port:
+ *   signal-cli -a +12025551234 daemon --http 7583 --no-receive-stdout
+ *
+ * ── Schema requirements ───────────────────────────────────────────────
+ *
+ * Add these columns to staff_agents (migration needed before wiring in):
+ *
+ *   signal_account      TEXT  -- E.164 phone number, e.g. "+12025551234"
+ *   signal_daemon_port  INTEGER  -- daemon HTTP port, e.g. 7583
+ *
+ * ── JSON-RPC wire format ──────────────────────────────────────────────
+ *
+ * All calls POST to http://localhost:<port>/api/v1/rpc
+ *
+ *   receive:     { method: "receive" }
+ *   send:        { method: "send", params: { recipient: ["+E164"], message: "…" } }
+ *   sendTyping:  { method: "sendTyping", params: { recipient: "+E164", stop: false } }
+ */
+
+import { EventEmitter } from "node:events";
+import http from "node:http";
+import { eq, and, desc } from "drizzle-orm";
+import type { Db } from "@carsonos/db";
+import {
+  staffAgents,
+  staffAssignments,
+  familyMembers,
+  conversations,
+} from "@carsonos/db";
+import type { ConstitutionEngine } from "./constitution-engine.js";
+import type { DelegationOrchestrator } from "./delegation-orchestrator.js";
+import { createSignalStream, markdownToSignalText, chunkSignalMessage } from "./signal-streaming.js";
+import { stripThinkingBlocks } from "./telegram-format.js";
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface SignalRelayConfig {
+  db: Db;
+  engine: ConstitutionEngine;
+  orchestrator: DelegationOrchestrator;
+}
+
+/** A staff agent row augmented with Signal-specific columns. */
+interface SignalAgent {
+  id: string;
+  name: string;
+  householdId: string;
+  signalAccount: string;   // E.164 phone number
+  signalDaemonPort: number; // signal-cli daemon HTTP port
+}
+
+interface ManagedAccount {
+  agentId: string;
+  agentName: string;
+  signalAccount: string;
+  daemonPort: number;
+  running: boolean;
+  /** Active SSE request — destroyed on intentional stop */
+  sseRequest: http.ClientRequest | null;
+  reconnectTimer: ReturnType<typeof setTimeout> | null;
+  reconnectAttempts: number;
+  lastActivity: number;
+  /** Timestamps of recently processed messages — dedup window */
+  recentTimestamps: Set<number>;
+  highestTimestamp: number;
+}
+
+interface DebounceBuffer {
+  messages: string[];
+  timer: ReturnType<typeof setTimeout>;
+  senderNumber: string;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+const RECONNECT_BASE_MS = 1_000;       // Initial reconnect delay
+const RECONNECT_MAX_MS = 30_000;       // Cap on reconnect backoff
+const DEBOUNCE_MS = 1_500;             // Paste buffering window
+const MAX_DEBOUNCE_PARTS = 12;
+const MAX_DEBOUNCE_CHARS = 50_000;
+const RATE_LIMIT = 20;
+const RATE_WINDOW_MS = 5 * 60 * 1000;
+const MAX_MESSAGE_LENGTH = 4_000;
+const DEDUP_MAX_SIZE = 2_000;
+const DAEMON_TIMEOUT_MS = 10_000;      // HTTP call timeout to daemon
+
+// ── JSON-RPC client ───────────────────────────────────────────────────
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  method: string;
+  params?: Record<string, unknown>;
+  id: string | number;
+}
+
+interface JsonRpcResponse<T = unknown> {
+  jsonrpc: "2.0";
+  result?: T;
+  error?: { code: number; message: string; data?: unknown };
+  id: string | number;
+}
+
+/** Signal envelope as returned by signal-cli receive. */
+interface SignalEnvelope {
+  account: string;
+  envelope: {
+    source: string;
+    sourceNumber: string;
+    sourceUuid?: string;
+    sourceName?: string;
+    sourceDevice: number;
+    timestamp: number;
+    dataMessage?: {
+      timestamp: number;
+      message: string | null;
+      groupInfo: unknown | null;
+      attachments?: unknown[];
+    };
+    typingMessage?: unknown;
+    receiptMessage?: unknown;
+    syncMessage?: unknown;
+  };
+}
+
+let _rpcIdCounter = 1;
+
+async function rpcCall<T = unknown>(
+  port: number,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<T> {
+  const body: JsonRpcRequest = {
+    jsonrpc: "2.0",
+    method,
+    params,
+    id: _rpcIdCounter++,
+  };
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DAEMON_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(`http://127.0.0.1:${port}/api/v1/rpc`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (!response.ok) {
+    throw new Error(`signal-cli daemon HTTP ${response.status}: ${await response.text()}`);
+  }
+
+  const json = (await response.json()) as JsonRpcResponse<T>;
+  if (json.error) {
+    throw new Error(`signal-cli RPC error ${json.error.code}: ${json.error.message}`);
+  }
+
+  return json.result as T;
+}
+
+/** Ping the daemon to verify it's reachable. */
+async function isDaemonHealthy(port: number): Promise<boolean> {
+  try {
+    // "version" is a lightweight no-op probe (signal-cli 0.14.x)
+    await rpcCall(port, "version");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── Rate limiter (shared with Telegram layer) ─────────────────────────
+
+class RateLimiter {
+  private windows = new Map<string, { count: number; windowStart: number }>();
+
+  check(key: string, limit: number, windowMs: number): boolean {
+    const now = Date.now();
+    const existing = this.windows.get(key);
+
+    if (!existing || now - existing.windowStart > windowMs) {
+      this.windows.set(key, { count: 1, windowStart: now });
+      return true;
+    }
+
+    if (existing.count >= limit) return false;
+    existing.count++;
+    return true;
+  }
+}
+
+// ── Signal Relay Manager ──────────────────────────────────────────────
+
+export class SignalRelayManager {
+  private db: Db;
+  private engine: ConstitutionEngine;
+  private orchestrator: DelegationOrchestrator;
+
+  private accounts = new Map<string, ManagedAccount>();
+  private rateLimiter = new RateLimiter();
+  private debounceBuffers = new Map<string, DebounceBuffer>();
+  private agentQueues = new Map<string, Promise<void>>();
+  private events = new EventEmitter();
+
+  constructor(config: SignalRelayConfig) {
+    this.db = config.db;
+    this.engine = config.engine;
+    this.orchestrator = config.orchestrator;
+
+    this.events.on(
+      "delegation.result",
+      (data: {
+        memberId: string | null;
+        agentId: string;
+        conversationId: string | null;
+        response: string;
+      }) => {
+        this.deliverDelegationResult(data);
+      },
+    );
+  }
+
+  get eventBus(): EventEmitter {
+    return this.events;
+  }
+
+  // ── Lifecycle ───────────────────────────────────────────────────────
+
+  async startAll(): Promise<void> {
+    const agents = await this.db
+      .select()
+      .from(staffAgents)
+      .where(
+        and(
+          eq(staffAgents.visibility, "family"),
+          eq(staffAgents.status, "active"),
+        ),
+      );
+
+    const signalAgents = agents
+      .map((a) => {
+        if (!a.signalAccount || !a.signalDaemonPort) return null;
+        return {
+          id: a.id,
+          name: a.name,
+          householdId: a.householdId,
+          signalAccount: a.signalAccount,
+          signalDaemonPort: a.signalDaemonPort,
+        } satisfies SignalAgent;
+      })
+      .filter((a): a is SignalAgent => a !== null);
+
+    if (signalAgents.length === 0) {
+      console.log("[signal-relay] No agents with Signal accounts configured");
+      return;
+    }
+
+    console.log(`[signal-relay] Starting ${signalAgents.length} Signal account(s)...`);
+
+    for (const agent of signalAgents) {
+      await this.startAccount(agent.id);
+    }
+  }
+
+  async stopAll(): Promise<void> {
+    const stopPromises: Promise<void>[] = [];
+    for (const [agentId, managed] of this.accounts) {
+      if (managed.running) {
+        stopPromises.push(
+          this.stopAccount(agentId).catch((err) => {
+            console.error(`[signal-relay] Error stopping ${managed.agentName}:`, err);
+          }),
+        );
+      }
+    }
+    await Promise.all(stopPromises);
+    this.accounts.clear();
+    console.log("[signal-relay] All Signal accounts stopped");
+  }
+
+  async startAccount(agentId: string): Promise<void> {
+    const existing = this.accounts.get(agentId);
+    if (existing?.running) {
+      console.log(`[signal-relay] Account for ${existing.agentName} already running`);
+      return;
+    }
+
+    const agent = await this.db
+      .select()
+      .from(staffAgents)
+      .where(eq(staffAgents.id, agentId))
+      .then((rows) => rows[0]);
+
+    if (!agent) {
+      console.error(`[signal-relay] Agent ${agentId} not found`);
+      return;
+    }
+
+    if (!agent.signalAccount || !agent.signalDaemonPort) {
+      console.error(`[signal-relay] Agent ${agent.name} has no Signal account or daemon port configured`);
+      return;
+    }
+
+    const signalAccount = agent.signalAccount;
+    const daemonPort = agent.signalDaemonPort;
+
+    // Verify daemon is reachable before starting the poll loop
+    const healthy = await isDaemonHealthy(daemonPort);
+    if (!healthy) {
+      console.error(
+        `[signal-relay] Daemon for ${agent.name} not reachable on port ${daemonPort}. ` +
+        `Start it with: signal-cli -a ${signalAccount} daemon --http ${daemonPort} --no-receive-stdout`,
+      );
+      return;
+    }
+
+    const managed: ManagedAccount = {
+      agentId,
+      agentName: agent.name,
+      signalAccount,
+      daemonPort,
+      running: false,
+      sseRequest: null,
+      reconnectTimer: null,
+      reconnectAttempts: 0,
+      lastActivity: Date.now(),
+      recentTimestamps: new Set(),
+      highestTimestamp: 0,
+    };
+
+    managed.running = true;
+    this.accounts.set(agentId, managed);
+    this.connectSSE(agentId);
+
+    console.log(
+      `[signal-relay] Started account for ${agent.name} (${signalAccount}) on daemon port ${daemonPort}`,
+    );
+  }
+
+  async stopAccount(agentId: string): Promise<void> {
+    const managed = this.accounts.get(agentId);
+    if (!managed) return;
+
+    // Mark stopped first so reconnect logic doesn't re-open after close
+    managed.running = false;
+
+    if (managed.reconnectTimer) {
+      clearTimeout(managed.reconnectTimer);
+      managed.reconnectTimer = null;
+    }
+
+    if (managed.sseRequest) {
+      managed.sseRequest.destroy();
+      managed.sseRequest = null;
+    }
+
+    this.accounts.delete(agentId);
+    console.log(`[signal-relay] Stopped account for ${managed.agentName}`);
+  }
+
+  // ── SSE receive layer ────────────────────────────────────────────────
+
+  /**
+   * Open a persistent SSE connection to the signal-cli daemon at
+   * GET /api/v1/events and process inbound envelopes as they arrive.
+   *
+   * signal-cli pushes each received envelope as an SSE event:
+   *   data: {"account":"…","envelope":{…}}\n\n
+   *
+   * Reconnects on close or error with exponential backoff, capped at
+   * RECONNECT_MAX_MS. Backoff resets to zero on each successful connection.
+   */
+  private connectSSE(agentId: string): void {
+    const managed = this.accounts.get(agentId);
+    if (!managed?.running) return;
+
+    const url = `http://127.0.0.1:${managed.daemonPort}/api/v1/events`;
+
+    const scheduleReconnect = (reason: string) => {
+      managed.sseRequest = null;
+
+      if (!managed.running) return; // intentional stop — do not reconnect
+
+      const delay = Math.min(
+        RECONNECT_BASE_MS * 2 ** managed.reconnectAttempts,
+        RECONNECT_MAX_MS,
+      );
+      managed.reconnectAttempts++;
+
+      console.warn(
+        `[signal-relay:${managed.agentName}] SSE disconnected (${reason}). ` +
+        `Reconnecting in ${delay / 1_000}s (attempt ${managed.reconnectAttempts})...`,
+      );
+
+      managed.reconnectTimer = setTimeout(() => {
+        managed.reconnectTimer = null;
+        this.connectSSE(agentId);
+      }, delay);
+    };
+
+    const req = http.get(url, (res) => {
+      if (res.statusCode !== 200) {
+        console.error(
+          `[signal-relay:${managed.agentName}] SSE endpoint returned HTTP ${res.statusCode}`,
+        );
+        res.resume(); // drain and discard
+        scheduleReconnect(`HTTP ${res.statusCode}`);
+        return;
+      }
+
+      managed.reconnectAttempts = 0;
+      managed.lastActivity = Date.now();
+      console.log(`[signal-relay:${managed.agentName}] SSE connected (${url})`);
+
+      let buf = "";
+
+      res.setEncoding("utf-8");
+      res.on("data", (chunk: string) => {
+        managed.lastActivity = Date.now();
+        buf += chunk;
+
+        // SSE frames are separated by double-newlines; process complete frames
+        const frames = buf.split(/\n\n+/);
+        buf = frames.pop() ?? ""; // last element may be incomplete
+
+        for (const frame of frames) {
+          for (const line of frame.split("\n")) {
+            if (!line.startsWith("data:")) continue;
+
+            const raw = line.slice(5).trim();
+            if (!raw) continue;
+
+            let parsed: unknown;
+            try {
+              parsed = JSON.parse(raw);
+            } catch {
+              console.warn(`[signal-relay:${managed.agentName}] Non-JSON SSE data — skipping`);
+              continue;
+            }
+
+            const envelope = (parsed as Record<string, unknown>).envelope as
+              | SignalEnvelope["envelope"]
+              | undefined;
+            if (!envelope) continue;
+
+            const dataMessage = envelope.dataMessage;
+            if (!dataMessage?.message) continue;       // typing, receipts, etc.
+            if (dataMessage.groupInfo) continue; // group messages — skip for now
+
+            const timestamp = envelope.timestamp;
+            const senderNumber = envelope.sourceNumber || envelope.source;
+            if (!senderNumber) continue;
+
+            // Deduplication by timestamp
+            if (managed.recentTimestamps.has(timestamp)) continue;
+            managed.recentTimestamps.add(timestamp);
+
+            if (timestamp > managed.highestTimestamp) {
+              managed.highestTimestamp = timestamp;
+            }
+
+            // Prune old dedup entries
+            if (managed.recentTimestamps.size > DEDUP_MAX_SIZE) {
+              const cutoff = managed.highestTimestamp - DEDUP_MAX_SIZE * 1_000;
+              for (const ts of managed.recentTimestamps) {
+                if (ts < cutoff) managed.recentTimestamps.delete(ts);
+              }
+            }
+
+            // Route to the message pipeline — errors are caught so one bad
+            // message never tears down the SSE connection
+            this.handleIncomingMessage(agentId, senderNumber, dataMessage.message).catch((err) => {
+              console.error(`[signal-relay:${managed.agentName}] handleIncomingMessage error:`, err);
+            });
+          }
+        }
+      });
+
+      res.on("end", () => scheduleReconnect("stream ended"));
+      res.on("error", (err) => scheduleReconnect(err.message));
+    });
+
+    req.on("error", (err) => scheduleReconnect(err.message));
+    req.setTimeout(0); // no request-level timeout — connection is intentionally long-lived
+
+    managed.sseRequest = req;
+  }
+
+  // ── Message handling ─────────────────────────────────────────────────
+
+  private async handleIncomingMessage(
+    agentId: string,
+    senderNumber: string,
+    text: string,
+  ): Promise<void> {
+    const managed = this.accounts.get(agentId);
+    if (!managed) return;
+
+    console.log(
+      `[signal-relay:${managed.agentName}] Message from ${senderNumber}: ${text.slice(0, 50)}`,
+    );
+
+    if (text.length > MAX_MESSAGE_LENGTH) {
+      await this.sendRaw(managed.daemonPort, senderNumber, "That message is too long. Try breaking it into shorter messages.");
+      return;
+    }
+
+    // Identify family member by signal_number field
+    // signal_number mirrors telegram_user_id: a nullable unique column
+    // that maps a Signal E.164 number to a family member record.
+    const member = await this.db
+      .select()
+      .from(familyMembers)
+      .where(eq(familyMembers.signalNumber, senderNumber))
+      .then((rows) => rows[0]);
+
+    if (!member) {
+      await this.sendRaw(
+        managed.daemonPort,
+        senderNumber,
+        "I don't recognize your number. Ask your family admin to add you in the CarsonOS dashboard.",
+      );
+      return;
+    }
+
+    // Verify agent is assigned to this member
+    const assignment = await this.db
+      .select()
+      .from(staffAssignments)
+      .where(
+        and(
+          eq(staffAssignments.agentId, agentId),
+          eq(staffAssignments.memberId, member.id),
+        ),
+      )
+      .then((rows) => rows[0]);
+
+    if (!assignment) {
+      await this.sendRaw(managed.daemonPort, senderNumber, "I'm not your assigned agent. Contact your household admin.");
+      return;
+    }
+
+    // Rate limit
+    if (!this.rateLimiter.check(member.id, RATE_LIMIT, RATE_WINDOW_MS)) {
+      await this.sendRaw(managed.daemonPort, senderNumber, "You're sending messages too fast. Please wait a moment.");
+      return;
+    }
+
+    // Paste debouncing — buffer rapid successive messages before processing
+    const bufferKey = `${agentId}:${member.id}`;
+    const existingBuf = this.debounceBuffers.get(bufferKey);
+
+    if (existingBuf) {
+      clearTimeout(existingBuf.timer);
+      const totalChars = existingBuf.messages.reduce((s, m) => s + m.length, 0) + text.length;
+
+      if (
+        existingBuf.messages.length < MAX_DEBOUNCE_PARTS &&
+        totalChars < MAX_DEBOUNCE_CHARS
+      ) {
+        existingBuf.messages.push(text);
+        existingBuf.timer = setTimeout(
+          () => this.flushBuffer(bufferKey, agentId, senderNumber, member),
+          DEBOUNCE_MS,
+        );
+      } else {
+        // Buffer full — flush now, start fresh
+        this.flushBuffer(bufferKey, agentId, senderNumber, member);
+        this.debounceBuffers.set(bufferKey, {
+          messages: [text],
+          senderNumber,
+          timer: setTimeout(
+            () => this.flushBuffer(bufferKey, agentId, senderNumber, member),
+            DEBOUNCE_MS,
+          ),
+        });
+      }
+    } else {
+      this.debounceBuffers.set(bufferKey, {
+        messages: [text],
+        senderNumber,
+        timer: setTimeout(
+          () => this.flushBuffer(bufferKey, agentId, senderNumber, member),
+          DEBOUNCE_MS,
+        ),
+      });
+    }
+  }
+
+  private flushBuffer(
+    bufferKey: string,
+    agentId: string,
+    senderNumber: string,
+    member: typeof familyMembers.$inferSelect,
+  ): void {
+    const buffer = this.debounceBuffers.get(bufferKey);
+    if (!buffer) return;
+
+    this.debounceBuffers.delete(bufferKey);
+
+    const combinedMessage = buffer.messages.join("\n");
+
+    // Serialize per-agent so responses don't interleave for concurrent senders
+    const previousWork = this.agentQueues.get(agentId) ?? Promise.resolve();
+    const currentWork = previousWork.then(async () => {
+      try {
+        await this.processMessage(agentId, senderNumber, member, combinedMessage);
+      } catch (err) {
+        console.error(`[signal-relay] processMessage error:`, err);
+        try {
+          await this.sendRaw(
+            this.accounts.get(agentId)!.daemonPort,
+            senderNumber,
+            "I'm having trouble right now. Try again in a minute.",
+          );
+        } catch { /* swallow */ }
+      }
+    });
+
+    this.agentQueues.set(agentId, currentWork);
+  }
+
+  private async processMessage(
+    agentId: string,
+    senderNumber: string,
+    member: typeof familyMembers.$inferSelect,
+    message: string,
+  ): Promise<void> {
+    const managed = this.accounts.get(agentId);
+    if (!managed) return;
+
+    const { daemonPort } = managed;
+
+    // Build the stream consumer: typing indicator + one-shot send on completion
+    const stream = createSignalStream(
+      // sendTyping
+      () => rpcCall(daemonPort, "sendTyping", { recipient: senderNumber, stop: false }),
+      // onComplete: deliver the final formatted text
+      (text) => this.sendFormatted(daemonPort, senderNumber, text),
+    );
+
+    // Run message through the constitution engine with streaming
+    let engineResult;
+    try {
+      engineResult = await this.engine.processMessage({
+        agentId,
+        memberId: member.id,
+        householdId: member.householdId,
+        message,
+        channel: "signal",
+        onTextDelta: stream.onDelta,
+      });
+    } catch (err) {
+      await stream.finish();
+      throw err;
+    }
+
+    // finish() stops the typing indicator and sends the accumulated text
+    await stream.finish();
+
+    if (engineResult.blocked) {
+      await this.sendFormatted(daemonPort, senderNumber, engineResult.response);
+      return;
+    }
+
+    // Run through delegation orchestrator
+    const conversationId = await this.getOrCreateConversationId(
+      agentId,
+      member.id,
+      member.householdId,
+    );
+
+    const delegationResult = await this.orchestrator.handleAgentResponse(
+      agentId,
+      member.id,
+      member.householdId,
+      conversationId,
+      engineResult.response,
+    );
+
+    if (delegationResult.warnings?.length) {
+      for (const w of delegationResult.warnings) {
+        console.warn(`[signal-relay:${managed.agentName}] Delegation warning: ${w}`);
+      }
+    }
+
+    // If delegated, the engine response already went out via stream.finish().
+    // Send the delegation acknowledgement if the orchestrator produced one.
+    if (delegationResult.delegated && delegationResult.userMessage) {
+      await this.sendFormatted(daemonPort, senderNumber, delegationResult.userMessage);
+    }
+  }
+
+  // ── Sending ─────────────────────────────────────────────────────────
+
+  /**
+   * Send plain text directly via the daemon — no formatting applied.
+   * Used for error messages and short system notices.
+   */
+  private async sendRaw(
+    daemonPort: number,
+    recipient: string,
+    text: string,
+  ): Promise<void> {
+    await rpcCall(daemonPort, "send", {
+      recipient: [recipient],
+      message: text.slice(0, MAX_MESSAGE_LENGTH),
+    });
+  }
+
+  /**
+   * Format markdown as Signal-friendly plain text, chunk if needed,
+   * and send each chunk in order.
+   */
+  private async sendFormatted(
+    daemonPort: number,
+    recipient: string,
+    text: string,
+  ): Promise<void> {
+    const cleaned = stripThinkingBlocks(text);
+    const formatted = markdownToSignalText(cleaned);
+    const chunks = chunkSignalMessage(formatted);
+
+    for (const chunk of chunks) {
+      if (!chunk.trim()) continue;
+      try {
+        await rpcCall(daemonPort, "send", {
+          recipient: [recipient],
+          message: chunk,
+        });
+      } catch (err) {
+        console.error(`[signal-relay] sendFormatted failed:`, err);
+        // Attempt plain truncated fallback
+        try {
+          await rpcCall(daemonPort, "send", {
+            recipient: [recipient],
+            message: cleaned.slice(0, MAX_MESSAGE_LENGTH),
+          });
+        } catch { /* give up */ }
+        break;
+      }
+    }
+  }
+
+  // ── Proactive sending (used by scheduler) ───────────────────────────
+
+  /**
+   * Send a message to a Signal number via a specific agent's account.
+   * Mirrors MultiRelayManager.sendMessage() for scheduler compatibility.
+   */
+  async sendMessage(
+    agentId: string,
+    signalNumber: string,
+    text: string,
+  ): Promise<void> {
+    const managed = this.accounts.get(agentId);
+    if (!managed?.running) {
+      throw new Error(`Signal account for agent ${agentId} is not running`);
+    }
+    await this.sendFormatted(managed.daemonPort, signalNumber, text);
+  }
+
+  /**
+   * Try every running account until one succeeds.
+   * Fallback for when the primary account can't reach a user.
+   * Returns true if any account succeeded.
+   */
+  async sendToAnyAccount(
+    signalNumber: string,
+    text: string,
+    excludeAgentId?: string,
+  ): Promise<boolean> {
+    for (const [agentId, managed] of this.accounts) {
+      if (agentId === excludeAgentId || !managed.running) continue;
+      try {
+        await this.sendFormatted(managed.daemonPort, signalNumber, text);
+        console.log(`[signal-relay] Fallback delivery via ${managed.agentName} succeeded`);
+        return true;
+      } catch { /* try next */ }
+    }
+    return false;
+  }
+
+  /**
+   * Check if any running account can reach a Signal number.
+   * Uses a lightweight send-typing probe; cached for 5 minutes.
+   */
+  private reachabilityCache = new Map<string, { reachable: boolean; expiresAt: number }>();
+
+  async canReachUser(signalNumber: string): Promise<boolean> {
+    const cached = this.reachabilityCache.get(signalNumber);
+    if (cached && Date.now() < cached.expiresAt) return cached.reachable;
+
+    for (const [, managed] of this.accounts) {
+      if (!managed.running) continue;
+      try {
+        // sendTyping stop=true is a no-op send that still validates reachability
+        await rpcCall(managed.daemonPort, "sendTyping", {
+          recipient: signalNumber,
+          stop: true,
+        });
+        this.reachabilityCache.set(signalNumber, {
+          reachable: true,
+          expiresAt: Date.now() + 5 * 60_000,
+        });
+        return true;
+      } catch { /* try next */ }
+    }
+
+    this.reachabilityCache.set(signalNumber, {
+      reachable: false,
+      expiresAt: Date.now() + 5 * 60_000,
+    });
+    return false;
+  }
+
+  // ── Delegation result delivery ────────────────────────────────────
+
+  private async deliverDelegationResult(data: {
+    memberId: string | null;
+    agentId: string;
+    conversationId: string | null;
+    response: string;
+  }): Promise<void> {
+    if (!data.memberId || !data.response) return;
+
+    const managed = this.accounts.get(data.agentId);
+    if (!managed?.running) {
+      console.warn(`[signal-relay] Cannot deliver delegation result: account for ${data.agentId} not running`);
+      return;
+    }
+
+    const member = await this.db
+      .select()
+      .from(familyMembers)
+      .where(eq(familyMembers.id, data.memberId))
+      .then((rows) => rows[0]);
+
+    const signalNumber = member?.signalNumber;
+    if (!signalNumber) {
+      console.warn(`[signal-relay] Cannot deliver: member ${data.memberId} has no Signal number`);
+      return;
+    }
+
+    try {
+      await this.sendFormatted(managed.daemonPort, signalNumber, data.response);
+      console.log(`[signal-relay:${managed.agentName}] Delivered delegation result to ${member?.name}`);
+    } catch (err) {
+      console.error(`[signal-relay:${managed.agentName}] Failed to deliver delegation result:`, err);
+    }
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────
+
+  private async getOrCreateConversationId(
+    agentId: string,
+    memberId: string,
+    householdId: string,
+  ): Promise<string> {
+    const today = new Date().toISOString().slice(0, 10);
+
+    const existing = await this.db
+      .select()
+      .from(conversations)
+      .where(
+        and(
+          eq(conversations.agentId, agentId),
+          eq(conversations.memberId, memberId),
+          eq(conversations.householdId, householdId),
+          eq(conversations.channel, "signal"),
+        ),
+      )
+      .orderBy(desc(conversations.startedAt))
+      .limit(1)
+      .then((rows) => rows[0]);
+
+    if (existing?.startedAt.startsWith(today)) {
+      return existing.id;
+    }
+
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    await this.db.insert(conversations).values({
+      id,
+      agentId,
+      memberId,
+      householdId,
+      channel: "signal",
+      startedAt: now,
+      lastMessageAt: now,
+    });
+
+    return id;
+  }
+}

--- a/server/src/services/signal-relay-manager.ts
+++ b/server/src/services/signal-relay-manager.ts
@@ -41,7 +41,7 @@
 
 import { EventEmitter } from "node:events";
 import http from "node:http";
-import { eq, and, desc } from "drizzle-orm";
+import { eq, and, or, desc } from "drizzle-orm";
 import type { Db } from "@carsonos/db";
 import {
   staffAgents,
@@ -475,8 +475,14 @@ export class SignalRelayManager {
             if (dataMessage.groupInfo) continue; // group messages — skip for now
 
             const timestamp = envelope.timestamp;
-            const senderNumber = envelope.sourceNumber || envelope.source;
-            if (!senderNumber) continue;
+            // Modern Signal clients may withhold sourceNumber if the sender
+            // has phone-number privacy enabled. In that case envelope.source
+            // is the ACI UUID and sourceUuid is populated. We keep track of
+            // both so identity lookup can match on either.
+            const senderNumber = envelope.sourceNumber || undefined;
+            const senderUuid = envelope.sourceUuid || (envelope.source && /^[0-9a-f-]{36}$/i.test(envelope.source) ? envelope.source : undefined);
+            const senderIdentifier = senderNumber || senderUuid || envelope.source;
+            if (!senderIdentifier) continue;
 
             // Deduplication by timestamp
             if (managed.recentTimestamps.has(timestamp)) continue;
@@ -496,7 +502,7 @@ export class SignalRelayManager {
 
             // Route to the message pipeline — errors are caught so one bad
             // message never tears down the SSE connection
-            this.handleIncomingMessage(agentId, senderNumber, dataMessage.message).catch((err) => {
+            this.handleIncomingMessage(agentId, senderIdentifier, senderNumber, senderUuid, dataMessage.message).catch((err) => {
               console.error(`[signal-relay:${managed.agentName}] handleIncomingMessage error:`, err);
             });
           }
@@ -517,37 +523,65 @@ export class SignalRelayManager {
 
   private async handleIncomingMessage(
     agentId: string,
-    senderNumber: string,
+    senderIdentifier: string,
+    senderNumber: string | undefined,
+    senderUuid: string | undefined,
     text: string,
   ): Promise<void> {
     const managed = this.accounts.get(agentId);
     if (!managed) return;
 
     console.log(
-      `[signal-relay:${managed.agentName}] Message from ${senderNumber}: ${text.slice(0, 50)}`,
+      `[signal-relay:${managed.agentName}] Message from ${senderIdentifier}: ${text.slice(0, 50)}`,
     );
 
     if (text.length > MAX_MESSAGE_LENGTH) {
-      await this.sendRaw(managed.daemonPort, senderNumber, "That message is too long. Try breaking it into shorter messages.");
+      await this.sendRaw(managed.daemonPort, senderIdentifier, "That message is too long. Try breaking it into shorter messages.");
       return;
     }
 
-    // Identify family member by signal_number field
-    // signal_number mirrors telegram_user_id: a nullable unique column
-    // that maps a Signal E.164 number to a family member record.
+    // Identify family member by signal_number OR signal_uuid. Modern Signal
+    // senders with phone-number privacy enabled deliver envelopes with only
+    // the ACI UUID, so we try to match on either identifier.
+    const identityClauses = [
+      senderNumber ? eq(familyMembers.signalNumber, senderNumber) : undefined,
+      senderUuid ? eq(familyMembers.signalUuid, senderUuid) : undefined,
+    ].filter((c): c is NonNullable<typeof c> => c !== undefined);
+
+    if (identityClauses.length === 0) {
+      await this.sendRaw(managed.daemonPort, senderIdentifier, "Could not identify your Signal account.");
+      return;
+    }
+
     const member = await this.db
       .select()
       .from(familyMembers)
-      .where(eq(familyMembers.signalNumber, senderNumber))
+      .where(identityClauses.length === 1 ? identityClauses[0] : or(...identityClauses))
       .then((rows) => rows[0]);
 
     if (!member) {
       await this.sendRaw(
         managed.daemonPort,
-        senderNumber,
-        "I don't recognize your number. Ask your family admin to add you in the CarsonOS dashboard.",
+        senderIdentifier,
+        "I don't recognize your Signal identity. Ask your family admin to add you in the CarsonOS dashboard.",
       );
       return;
+    }
+
+    // Opportunistically backfill the other identifier when we matched on one
+    // and the envelope provided the other. Lets admins bootstrap with just
+    // the UUID or just the phone and auto-fill the counterpart on first
+    // successful message.
+    const needsNumberFill = senderNumber && !member.signalNumber;
+    const needsUuidFill = senderUuid && !member.signalUuid;
+    if (needsNumberFill || needsUuidFill) {
+      await this.db
+        .update(familyMembers)
+        .set({
+          ...(needsNumberFill && { signalNumber: senderNumber }),
+          ...(needsUuidFill && { signalUuid: senderUuid }),
+        })
+        .where(eq(familyMembers.id, member.id));
     }
 
     // Verify agent is assigned to this member
@@ -563,13 +597,13 @@ export class SignalRelayManager {
       .then((rows) => rows[0]);
 
     if (!assignment) {
-      await this.sendRaw(managed.daemonPort, senderNumber, "I'm not your assigned agent. Contact your household admin.");
+      await this.sendRaw(managed.daemonPort, senderIdentifier, "I'm not your assigned agent. Contact your household admin.");
       return;
     }
 
     // Rate limit
     if (!this.rateLimiter.check(member.id, RATE_LIMIT, RATE_WINDOW_MS)) {
-      await this.sendRaw(managed.daemonPort, senderNumber, "You're sending messages too fast. Please wait a moment.");
+      await this.sendRaw(managed.daemonPort, senderIdentifier, "You're sending messages too fast. Please wait a moment.");
       return;
     }
 
@@ -587,17 +621,17 @@ export class SignalRelayManager {
       ) {
         existingBuf.messages.push(text);
         existingBuf.timer = setTimeout(
-          () => this.flushBuffer(bufferKey, agentId, senderNumber, member),
+          () => this.flushBuffer(bufferKey, agentId, senderIdentifier, member),
           DEBOUNCE_MS,
         );
       } else {
         // Buffer full — flush now, start fresh
-        this.flushBuffer(bufferKey, agentId, senderNumber, member);
+        this.flushBuffer(bufferKey, agentId, senderIdentifier, member);
         this.debounceBuffers.set(bufferKey, {
           messages: [text],
-          senderNumber,
+          senderNumber: senderIdentifier,
           timer: setTimeout(
-            () => this.flushBuffer(bufferKey, agentId, senderNumber, member),
+            () => this.flushBuffer(bufferKey, agentId, senderIdentifier, member),
             DEBOUNCE_MS,
           ),
         });
@@ -605,9 +639,9 @@ export class SignalRelayManager {
     } else {
       this.debounceBuffers.set(bufferKey, {
         messages: [text],
-        senderNumber,
+        senderNumber: senderIdentifier,
         timer: setTimeout(
-          () => this.flushBuffer(bufferKey, agentId, senderNumber, member),
+          () => this.flushBuffer(bufferKey, agentId, senderIdentifier, member),
           DEBOUNCE_MS,
         ),
       });

--- a/server/src/services/signal-streaming.ts
+++ b/server/src/services/signal-streaming.ts
@@ -148,10 +148,14 @@ export function createSignalStream(
 
   const onDelta = (text: string): void => {
     if (finished) return;
-    // Start typing indicator on the very first token
-    if (accumulated === "") startTyping();
     accumulated += text;
   };
+
+  // Start typing indicator immediately at construction — user sees
+  // "Carson is typing..." as soon as the relay accepts the message, not
+  // only after Claude produces its first text token (which may be 5-15s in
+  // with thinking-mode models).
+  startTyping();
 
   const finish = async (): Promise<SignalStreamResult> => {
     finished = true;

--- a/server/src/services/signal-streaming.ts
+++ b/server/src/services/signal-streaming.ts
@@ -1,0 +1,175 @@
+/**
+ * Signal streaming engine — accumulate-and-send with typing indicators.
+ *
+ * Signal has no edit-in-place API (unlike Telegram's editMessageText), so
+ * rather than sending partial updates we accumulate all tokens, keep the
+ * typing indicator alive while the LLM runs, and deliver the complete
+ * formatted text in a single send when finish() is called.
+ *
+ * The interface mirrors TelegramStreamConsumer so the constitution engine
+ * can use either transport without modification — both expose onDelta and
+ * finish(), and the engine only calls onDelta with text deltas.
+ */
+
+import { stripThinkingBlocks } from "./telegram-format.js";
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface SignalStreamResult {
+  text: string;
+}
+
+export interface SignalStreamConsumer {
+  onDelta: (text: string) => void;
+  finish: () => Promise<SignalStreamResult>;
+}
+
+// ── Signal text formatting ─────────────────────────────────────────────
+
+/**
+ * Convert LLM markdown output to Signal-friendly plain text.
+ *
+ * Signal renders messages as plain text — no HTML, no markdown.
+ * We strip markdown syntax and make the result readable as-is.
+ * Code blocks are preserved with indentation; headers and lists
+ * are retained but stripped of their syntax markers.
+ */
+export function markdownToSignalText(text: string): string {
+  return text
+    // Fenced code blocks: strip fences, preserve content with a blank line
+    .replace(/```[\w]*\n?([\s\S]*?)```/g, (_, code: string) => {
+      const trimmed = code.trim();
+      return trimmed ? `\n${trimmed}\n` : "";
+    })
+    // Inline code: strip backticks, keep content
+    .replace(/`([^`\n]+)`/g, "$1")
+    // Bold (**text** or __text__): keep content
+    .replace(/\*\*([^*\n]+)\*\*/g, "$1")
+    .replace(/__([^_\n]+)__/g, "$1")
+    // Italic (*text* or _text_): keep content
+    .replace(/\*([^*\n]+)\*/g, "$1")
+    .replace(/_([^_\n]+)_/g, "$1")
+    // Strikethrough
+    .replace(/~~([^~\n]+)~~/g, "$1")
+    // ATX headers (# ## ###): keep text, no special prefix
+    .replace(/^#{1,6}\s+(.+)$/gm, "$1")
+    // Horizontal rules → unicode dash line
+    .replace(/^[-*_]{3,}\s*$/gm, "─────────────")
+    // Blockquotes: strip >
+    .replace(/^>\s?/gm, "")
+    // Unordered list items: normalize bullet
+    .replace(/^[ \t]*[-*+]\s+/gm, "• ")
+    // Ordered list items: keep numbering
+    .replace(/^[ \t]*(\d+)\.\s+/gm, "$1. ")
+    // Collapse 3+ consecutive newlines to 2
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/**
+ * Split a long message into chunks that fit within Signal's message size
+ * limit (~60KB in practice; we use 4000 chars as a conservative limit to
+ * keep messages readable).
+ *
+ * Splits on paragraph boundaries where possible.
+ */
+export function chunkSignalMessage(text: string, maxChars = 4000): string[] {
+  if (text.length <= maxChars) return [text];
+
+  const chunks: string[] = [];
+  const paragraphs = text.split(/\n\n+/);
+  let current = "";
+
+  for (const para of paragraphs) {
+    const candidate = current ? `${current}\n\n${para}` : para;
+
+    if (candidate.length <= maxChars) {
+      current = candidate;
+    } else {
+      if (current) chunks.push(current);
+
+      // Paragraph itself is too long — hard split on word boundary
+      if (para.length > maxChars) {
+        let remaining = para;
+        while (remaining.length > maxChars) {
+          const cut = remaining.lastIndexOf(" ", maxChars);
+          const splitAt = cut > 0 ? cut : maxChars;
+          chunks.push(remaining.slice(0, splitAt).trim());
+          remaining = remaining.slice(splitAt).trim();
+        }
+        current = remaining;
+      } else {
+        current = para;
+      }
+    }
+  }
+
+  if (current) chunks.push(current);
+  return chunks.filter((c) => c.trim().length > 0);
+}
+
+// ── Stream Consumer ────────────────────────────────────────────────────
+
+/**
+ * Create a Signal stream consumer.
+ *
+ * `sendTyping` — called immediately on the first delta and every 4s
+ *   thereafter to keep Signal's typing indicator alive. Errors are
+ *   swallowed so a failed typing call doesn't abort the LLM pipeline.
+ *
+ * `onComplete` — called once with the final formatted text when finish()
+ *   is called. Responsible for the actual send.
+ */
+export function createSignalStream(
+  sendTyping: () => Promise<void>,
+  onComplete: (text: string) => Promise<void>,
+): SignalStreamConsumer {
+  let accumulated = "";
+  let finished = false;
+  let typingInterval: ReturnType<typeof setInterval> | null = null;
+  let typingStarted = false;
+
+  const startTyping = () => {
+    if (typingStarted) return;
+    typingStarted = true;
+    // Fire immediately, then refresh every 4s (Signal indicator expires ~5s)
+    sendTyping().catch(() => {});
+    typingInterval = setInterval(() => {
+      sendTyping().catch(() => {});
+    }, 4_000);
+  };
+
+  const stopTyping = () => {
+    if (typingInterval) {
+      clearInterval(typingInterval);
+      typingInterval = null;
+    }
+  };
+
+  const onDelta = (text: string): void => {
+    if (finished) return;
+    // Start typing indicator on the very first token
+    if (accumulated === "") startTyping();
+    accumulated += text;
+  };
+
+  const finish = async (): Promise<SignalStreamResult> => {
+    finished = true;
+    stopTyping();
+
+    const cleaned = stripThinkingBlocks(accumulated);
+    const formatted = markdownToSignalText(cleaned);
+
+    if (formatted) {
+      try {
+        await onComplete(formatted);
+      } catch (err) {
+        console.error("[signal-stream] Failed to deliver message:", err);
+      }
+    }
+
+    return { text: accumulated };
+  };
+
+  return { onDelta, finish };
+}


### PR DESCRIPTION
## Summary

Adds Signal as a messaging channel for CarsonOS agents, using signal-cli in HTTP daemon mode. Rebased onto v0.3.0 with requested fixes from PR #13 review.

## Changes from PR #13

- Rebased onto v0.3.0 main
- `signalRelay.stopAll()` added to the new shutdown block alongside `multiRelay.stopAll()`
- `taskEngine` removed from `SignalRelayManager` — was copied from `MultiRelayManager` but never used
- New branch `feat/signal-transport` per Josh's branch hygiene request
- Closes #13

## What's included

- `server/src/services/signal-streaming.ts` — accumulate-and-send streaming with typing indicator. Signal has no edit-in-place API unlike Telegram, so tokens are accumulated and delivered as a single message on completion.
- `server/src/services/signal-relay-manager.ts` — receives inbound messages via SSE (`/api/v1/events`) and sends outbound via JSON-RPC HTTP. Mirrors the MultiRelayManager pipeline: dedup, identity lookup, rate limiting, paste debounce, per-agent serial queue, constitution engine, delegation.
- SSE envelope account validation — rejects envelopes whose `account` field doesn't match the agent's configured Signal account
- Double-send fix — blocked messages discard the stream buffer before sending the policy response
- 178 tests passing including 25 new tests for `markdownToSignalText`, `chunkSignalMessage`, and `SignalStreamConsumer`
- Database migration adding `signal_account`, `signal_daemon_port` to `staff_agents` and `signal_number` to `family_members`
- Staff routes updated to call `startAccount()` on signal_account set/update

## Setup

Install signal-cli (Homebrew on macOS: `brew install signal-cli`), register a dedicated number, and start the daemon:

```bash
signal-cli -a +1XXXXXXXXXX register --captcha '<token>'
signal-cli -a +1XXXXXXXXXX verify <code>
signal-cli -a +1XXXXXXXXXX daemon --http 127.0.0.1:8080
```

Then set `signal_account` and `signal_daemon_port` on the agent, and `signal_number` on each family member.

## Notes

- Tested on macOS with signal-cli 0.14.2 (Homebrew). The `--http` flag exposes SSE at `/api/v1/events` — WebSocket is not available in this build, so the relay uses SSE.
- The health probe uses the `version` RPC method (`getVersion` is not implemented in 0.14.2).
- signal-cli's JVM build has a cold-start delay on first message. Native build would reduce this.