### PR TITLE
fix(memory): expand tilde in memoryDir, add read_memory tool

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -219,6 +219,7 @@ export interface MemorySearchResult {
 
 export interface MemoryProvider {
   search(query: string, collection: string, limit?: number): Promise<MemorySearchResult>;
+  read(collection: string, id: string): Promise<{ id: string; title: string; content: string; frontmatter: Record<string, unknown>; filePath: string } | null>;
   save(collection: string, entry: {
     type: MemoryType;
     title: string;

--- a/server/src/services/imap/imap-provider.ts
+++ b/server/src/services/imap/imap-provider.ts
@@ -135,15 +135,15 @@ export class ImapProvider {
 
     await withTimeout(client.connect(), TIMEOUT_MS);
     try {
-      const lock = await withTimeout(client.getMailboxLock(mailbox), TIMEOUT_MS);
+      const lock = (await withTimeout(client.getMailboxLock(mailbox), TIMEOUT_MS)) as { release: () => void };
       try {
         const query: SearchObject = unreadOnly ? { seen: false } : { all: true };
-        const uids = await withTimeout(client.search(query, { uid: true }), TIMEOUT_MS);
+        const uids = (await withTimeout(client.search(query, { uid: true }), TIMEOUT_MS)) as number[] | false;
 
         if (!uids || uids.length === 0) return [];
 
         // Take the last `max` UIDs (highest = most recently received)
-        const recent = (uids as number[]).slice(-max);
+        const recent = uids.slice(-max);
         return await fetchEnvelopes(client, recent, mailbox);
       } finally {
         lock.release();
@@ -164,12 +164,20 @@ export class ImapProvider {
 
     await withTimeout(client.connect(), TIMEOUT_MS);
     try {
-      const lock = await withTimeout(client.getMailboxLock(mailbox), TIMEOUT_MS);
+      const lock = (await withTimeout(client.getMailboxLock(mailbox), TIMEOUT_MS)) as { release: () => void };
       try {
-        const msg = await withTimeout(
+        const msg = (await withTimeout(
           client.fetchOne(uid, { envelope: true, source: true, uid: true }, { uid: true }),
           TIMEOUT_MS,
-        );
+        )) as {
+          envelope?: {
+            from?: Array<{ name?: string; address?: string }>;
+            to?: Array<{ name?: string; address?: string }>;
+            subject?: string;
+            date?: Date | string;
+          };
+          source?: Buffer;
+        } | undefined;
 
         if (!msg) {
           throw new Error(`Message not found: ${messageId}`);
@@ -214,14 +222,14 @@ export class ImapProvider {
 
     await withTimeout(client.connect(), TIMEOUT_MS);
     try {
-      const lock = await withTimeout(client.getMailboxLock(mailbox), TIMEOUT_MS);
+      const lock = (await withTimeout(client.getMailboxLock(mailbox), TIMEOUT_MS)) as { release: () => void };
       try {
         const searchObj = parseSearchQuery(query);
-        const uids = await withTimeout(client.search(searchObj, { uid: true }), TIMEOUT_MS);
+        const uids = (await withTimeout(client.search(searchObj, { uid: true }), TIMEOUT_MS)) as number[] | false;
 
         if (!uids || uids.length === 0) return [];
 
-        const recent = (uids as number[]).slice(-max);
+        const recent = uids.slice(-max);
         return await fetchEnvelopes(client, recent, mailbox);
       } finally {
         lock.release();

--- a/server/src/services/memory/memory-tools.ts
+++ b/server/src/services/memory/memory-tools.ts
@@ -141,6 +141,26 @@ export const MEMORY_TOOLS: ToolDefinition[] = [
       required: ["id", "collection"],
     },
   },
+  {
+    name: "read_memory",
+    description:
+      "Read the full content of a specific memory entry. Use after search_memory when the snippet preview isn't enough — for example, when the user asks for a URL, quote, or detail that lives inside the body of a memory rather than its title.",
+    input_schema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          description: "The memory ID to read (from a prior search_memory result).",
+        },
+        collection: {
+          type: "string",
+          description:
+            "Which collection the memory lives in. Matches the collection name from search_memory results (e.g. 'josh', 'household').",
+        },
+      },
+      required: ["id", "collection"],
+    },
+  },
 ];
 
 // ── Tool context ───────────────────────────────────────────────────
@@ -193,6 +213,9 @@ export function buildToolExecutor(
           break;
         case "delete_memory":
           result = await handleDeleteMemory(ctx, input);
+          break;
+        case "read_memory":
+          result = await handleReadMemory(ctx, input);
           break;
         default:
           result = { content: `Unknown tool: ${name}`, is_error: true };
@@ -338,5 +361,33 @@ async function handleDeleteMemory(
 
   await ctx.memoryProvider.delete(collection, id);
   return { content: `Memory "${id}" deleted from ${collection}.` };
+}
+
+async function handleReadMemory(
+  ctx: ToolContext,
+  input: Record<string, unknown>,
+): Promise<ToolResult> {
+  const id = input.id as string;
+  const collection = input.collection as string;
+
+  if (ctx.allowedCollections && !ctx.allowedCollections.includes(collection)) {
+    return { content: `You don't have access to the "${collection}" collection.`, is_error: true };
+  }
+
+  const entry = await ctx.memoryProvider.read(collection, id);
+  if (!entry) {
+    return { content: `Memory "${id}" not found in collection "${collection}".`, is_error: true };
+  }
+
+  const fmLines = Object.entries(entry.frontmatter)
+    .map(([k, v]) => {
+      if (Array.isArray(v)) return `${k}: ${v.join(", ")}`;
+      return `${k}: ${String(v)}`;
+    })
+    .join("\n");
+
+  return {
+    content: `[${collection}] ${entry.title} (id: ${entry.id})\n\n--- frontmatter ---\n${fmLines}\n\n--- content ---\n${entry.content}`,
+  };
 }
 

--- a/server/src/services/memory/qmd-provider.ts
+++ b/server/src/services/memory/qmd-provider.ts
@@ -20,6 +20,7 @@ import {
   existsSync,
 } from "node:fs";
 import { join, basename } from "node:path";
+import { homedir } from "node:os";
 import type {
   MemoryProvider,
   MemoryEntry,
@@ -32,6 +33,18 @@ const execFileAsync = promisify(execFile);
 const QMD_BIN = "qmd";
 const SEARCH_TIMEOUT_MS = 30_000; // qmd query (hybrid) can take 5-10s
 const UPDATE_TIMEOUT_MS = 30_000;
+
+/**
+ * Expand a leading `~` or `~/` in a path to the user's home directory.
+ * Node's fs and path APIs don't do this automatically — it's a shell thing —
+ * so stored paths like `~/projects/brain` fail silently by creating a
+ * literal `~` directory relative to cwd if we don't expand them first.
+ */
+function expandHome(path: string): string {
+  if (path === "~") return homedir();
+  if (path.startsWith("~/")) return join(homedir(), path.slice(2));
+  return path;
+}
 
 // ── QMD Provider ───────────────────────────────────────────────────
 
@@ -59,7 +72,8 @@ export class QmdMemoryProvider implements MemoryProvider {
    * instead of creating a new one (avoids duplicate indexing).
    */
   async ensureCollection(name: string, dirOverride?: string): Promise<void> {
-    const dir = dirOverride ?? join(this.rootDir, name);
+    const expandedOverride = dirOverride ? expandHome(dirOverride) : undefined;
+    const dir = expandedOverride ?? join(this.rootDir, name);
     mkdirSync(dir, { recursive: true });
 
     // Check if QMD already has this directory under a different name
@@ -76,8 +90,8 @@ export class QmdMemoryProvider implements MemoryProvider {
 
       // If dirOverride is set, check if that directory is already registered
       // under a different collection name. If so, alias to it.
-      if (dirOverride) {
-        const resolvedDir = dirOverride.replace(/\/$/, "");
+      if (expandedOverride) {
+        const resolvedDir = expandedOverride.replace(/\/$/, "");
         // Extract collection names from the list output
         const collectionNames = [...stdout.matchAll(/^(\S+)\s+\(qmd:\/\//gm)].map(m => m[1]);
 
@@ -290,19 +304,67 @@ export class QmdMemoryProvider implements MemoryProvider {
     return { id, filePath };
   }
 
-  /** Find a memory file by ID — checks filename first, then frontmatter. */
+  /**
+   * Find a memory file by ID — checks filename first, then frontmatter.
+   * Walks the directory recursively so both flat collections (written by
+   * save()) and nested brain-style collections (knowledge/year/foo.md) work.
+   */
   private findMemoryFile(dir: string, id: string): string | null {
     const direct = join(dir, `${id}.md`);
     if (existsSync(direct)) return direct;
 
-    const files = readdirSync(dir).filter((f) => f.endsWith(".md"));
-    for (const file of files) {
-      const content = readFileSync(join(dir, file), "utf-8");
-      if (content.includes(`id: ${id}`)) {
-        return join(dir, file);
+    // Recursive walk. Skip hidden directories (.git, .obsidian) — they
+    // can contain thousands of files and never hold memories.
+    const walk = (current: string): string | null => {
+      let entries: import("node:fs").Dirent[];
+      try {
+        entries = readdirSync(current, { withFileTypes: true, encoding: "utf8" }) as import("node:fs").Dirent[];
+      } catch {
+        return null;
       }
-    }
-    return null;
+      for (const entry of entries) {
+        const name = entry.name;
+        if (name.startsWith(".")) continue;
+        const full = join(current, name);
+        if (entry.isDirectory()) {
+          const found = walk(full);
+          if (found) return found;
+          continue;
+        }
+        if (!name.endsWith(".md")) continue;
+        if (name === `${id}.md`) return full;
+        try {
+          const content = readFileSync(full, "utf-8");
+          if (content.includes(`id: ${id}`)) return full;
+        } catch {
+          // Skip unreadable files
+        }
+      }
+      return null;
+    };
+
+    return walk(dir);
+  }
+
+  async read(
+    collection: string,
+    id: string,
+  ): Promise<{ id: string; title: string; content: string; frontmatter: Record<string, unknown>; filePath: string } | null> {
+    const dir = this.collections.get(collection);
+    if (!dir) return null;
+
+    const filePath = this.findMemoryFile(dir, id);
+    if (!filePath) return null;
+
+    const raw = readFileSync(filePath, "utf-8");
+    const parsed = parseMemoryFile(raw, filePath, collection);
+    return {
+      id: parsed?.id ?? id,
+      title: parsed?.title ?? id,
+      content: parsed?.content ?? raw,
+      frontmatter: parsed?.frontmatter ?? {},
+      filePath,
+    };
   }
 
   async delete(collection: string, id: string): Promise<void> {

--- a/server/src/services/tool-registry.ts
+++ b/server/src/services/tool-registry.ts
@@ -119,34 +119,34 @@ const CUSTOM_TOOL_MGMT_GRANTS = [
 
 const DEFAULT_GRANTS: Record<string, string[]> = {
   head_butler: [
-    "search_memory", "save_memory", "delete_memory", "update_instructions",
+    "search_memory", "read_memory", "save_memory", "delete_memory", "update_instructions",
     "list_calendar_events", "create_calendar_event", "get_calendar_event",
     "gmail_triage", "gmail_read", "gmail_compose", "gmail_reply", "gmail_update_draft", "gmail_send_draft", "gmail_search",
     "drive_search", "drive_list",
     ...CUSTOM_TOOL_MGMT_GRANTS,
   ],
   personal: [
-    "search_memory", "save_memory", "delete_memory", "update_instructions",
+    "search_memory", "read_memory", "save_memory", "delete_memory", "update_instructions",
     "list_calendar_events", "create_calendar_event", "get_calendar_event",
     "gmail_triage", "gmail_read", "gmail_compose", "gmail_reply", "gmail_update_draft", "gmail_send_draft", "gmail_search",
     "drive_search", "drive_list",
   ],
   tutor: [
-    "search_memory", "save_memory", "update_instructions",
+    "search_memory", "read_memory", "save_memory", "update_instructions",
     "list_calendar_events",
     "drive_search",
   ],
   coach: [
-    "search_memory", "save_memory", "update_instructions",
+    "search_memory", "read_memory", "save_memory", "update_instructions",
     "list_calendar_events",
   ],
   scheduler: [
-    "search_memory", "save_memory", "update_instructions",
+    "search_memory", "read_memory", "save_memory", "update_instructions",
     "list_calendar_events", "create_calendar_event", "get_calendar_event",
     "gmail_triage", "gmail_read", "gmail_search",
   ],
   custom: [
-    "search_memory", "update_instructions",
+    "search_memory", "read_memory", "update_instructions",
   ],
 };
 


### PR DESCRIPTION
## Summary

Follow-up discovered during PR #22 Signal testing. Agents with an external brain directory (`memoryDir` set to `~/projects/brain`) couldn't actually read from it — and once they could, they had no way to drill into a specific entry because \`search_memory\` only returned short snippets.

Also hotfixes a pre-existing typecheck failure in \`imap-provider.ts\` so \`pnpm build\` is green on main again.

## Memory — tilde expansion

The real brain is at \`/Users/joshdaws/projects/brain\` (1,201 files) already registered in QMD under the collection name \`brain\`. But the family_member record stored \`~/projects/brain\` as the path. \`mkdirSync\` doesn't expand tildes — Node's fs APIs treat \`~\` as a literal directory name — so boot was creating \`server/~/projects/brain\` and registering a useless empty collection under the name \`josh\`. search_memory returned zero hits.

Fix: new \`expandHome()\` helper in \`qmd-provider.ts\`, applied to \`dirOverride\` before both \`mkdirSync\` and the path-comparison step that aliases to existing QMD collections. Boot log now shows \`[memory] Collection "josh" → existing QMD collection "brain" at /Users/joshdaws/projects/brain\`.

## Memory — read_memory tool

QMD's \`--json\` output returns only ~4 lines of snippet per hit. When the user asked \"give me the URL\" for a memory, Carson correctly found the entry via search_memory but couldn't reach into the body to pull the URL out. mr-carson solves this with a \`brain get <path>\` action that reads the full file — we now have the equivalent.

New \`read_memory\` tool:
- Input: \`{ id, collection }\` from a prior \`search_memory\` result
- Output: full frontmatter + body
- Implemented on \`MemoryProvider.read()\` (new interface method). QmdMemoryProvider walks the collection directory recursively (fixes nested layouts like \`knowledge/2026-04-10-foo.md\`) and parses the file.
- Granted by default to: head_butler, personal, tutor, coach, scheduler, custom

## IMAP — typecheck hotfix (scope creep, necessary)

\`imap-provider.ts\` from PR #15 was failing \`tsc --noEmit\` after a clean build — \`withTimeout<T>(promise)\` collapses to \`unknown\` / \`{}\` when imapflow's own types are loose. Added local casts at the three problematic call sites (\`getMailboxLock\`, \`search\`, \`fetchOne\`) to restore the expected shapes. Not an imapflow version bump, not a behavior change — just type hints at the boundary. Without this, this PR's typecheck couldn't pass.

## Test plan

- [x] \`pnpm typecheck\` clean across all packages
- [x] \`pnpm test\` — 191/191 passing
- [x] \`pnpm build\` — green
- [x] Live-tested on main instance: Carson successfully searches Josh's brain and retrieves full memory content via \`read_memory\`, including URLs from the body
- [x] Signal + Telegram both benefit — transport-agnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)