### PR TITLE
feat: SSE streaming for web chat

### DIFF
--- a/server/src/routes/__tests__/conversations.test.ts
+++ b/server/src/routes/__tests__/conversations.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for web chat conversation route logic.
+ *
+ * Route handlers have Express/DB dependencies that are expensive to mock
+ * fully, so we test the validation predicates and response-shaping logic
+ * extracted inline — the same approach used by onboarding.test.ts.
+ * For each guard in the handler we verify both the rejection case (what the
+ * route returns early) and the acceptance case (what fields are required to
+ * proceed).
+ */
+
+import { describe, it, expect } from "vitest";
+
+// ── POST /conversations input validation ───────────────────────────
+//
+// Route guard: if (!agentId || !memberId) → 400
+// This mirrors the exact check in the handler so any relaxation (e.g.
+// making memberId optional) requires updating both handler and test.
+
+function validateCreateConversation(body: {
+  agentId?: unknown;
+  memberId?: unknown;
+}): { valid: true } | { valid: false; error: string } {
+  if (!body.agentId || !body.memberId) {
+    return { valid: false, error: "agentId and memberId are required" };
+  }
+  return { valid: true };
+}
+
+describe("POST /conversations — body validation", () => {
+  it("rejects when both agentId and memberId are missing", () => {
+    const result = validateCreateConversation({});
+    expect(result.valid).toBe(false);
+    expect((result as { valid: false; error: string }).error).toBe(
+      "agentId and memberId are required",
+    );
+  });
+
+  it("rejects when agentId is missing (memberId present)", () => {
+    const result = validateCreateConversation({ memberId: "member-1" });
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects when memberId is missing (agentId present)", () => {
+    const result = validateCreateConversation({ agentId: "agent-1" });
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects empty string agentId", () => {
+    const result = validateCreateConversation({ agentId: "", memberId: "member-1" });
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects empty string memberId", () => {
+    const result = validateCreateConversation({ agentId: "agent-1", memberId: "" });
+    expect(result.valid).toBe(false);
+  });
+
+  it("accepts valid agentId and memberId", () => {
+    const result = validateCreateConversation({ agentId: "agent-abc", memberId: "member-xyz" });
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts UUID-shaped IDs (typical DB output)", () => {
+    const result = validateCreateConversation({
+      agentId: "550e8400-e29b-41d4-a716-446655440000",
+      memberId: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+    });
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ── New conversation shape ─────────────────────────────────────────
+//
+// The route inserts { householdId, agentId, memberId, channel: "web", startedAt }.
+// Test that the shape builder produces all required fields and that
+// channel is always "web" (not leaked from body).
+
+function buildConversationInsert(opts: {
+  agentId: string;
+  memberId: string;
+  householdId: string;
+}): {
+  agentId: string;
+  memberId: string;
+  householdId: string;
+  channel: string;
+  startedAt: string;
+} {
+  return {
+    householdId: opts.householdId,
+    agentId: opts.agentId,
+    memberId: opts.memberId,
+    channel: "web",
+    startedAt: new Date().toISOString(),
+  };
+}
+
+describe("POST /conversations — insert shape", () => {
+  it("channel is always 'web', regardless of caller input", () => {
+    const insert = buildConversationInsert({
+      agentId: "a",
+      memberId: "m",
+      householdId: "h",
+    });
+    expect(insert.channel).toBe("web");
+  });
+
+  it("householdId is derived from the member row, not the request body", () => {
+    // The route fetches the member first and uses member.householdId — the
+    // caller never supplies householdId directly. This shape test validates
+    // that the householdId comes from the DB lookup result.
+    const memberRow = { id: "m", householdId: "household-from-db" };
+    const insert = buildConversationInsert({
+      agentId: "a",
+      memberId: memberRow.id,
+      householdId: memberRow.householdId,
+    });
+    expect(insert.householdId).toBe("household-from-db");
+  });
+
+  it("startedAt is a valid ISO 8601 timestamp", () => {
+    const insert = buildConversationInsert({ agentId: "a", memberId: "m", householdId: "h" });
+    const parsed = new Date(insert.startedAt);
+    expect(isNaN(parsed.getTime())).toBe(false);
+  });
+
+  it("startedAt is close to now (within 1 second)", () => {
+    const before = Date.now();
+    const insert = buildConversationInsert({ agentId: "a", memberId: "m", householdId: "h" });
+    const after = Date.now();
+    const ts = new Date(insert.startedAt).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after + 1000);
+  });
+});
+
+// ── POST /:id/messages — body validation ──────────────────────────
+//
+// Route guard: if (!message || typeof message !== "string") → 400
+// The field is called `message`, not `content` — this was a bug that was
+// fixed (UI was sending { content, role } instead of { message }).
+// Keeping this test ensures we don't regress back.
+
+function validateSendMessage(body: { message?: unknown }): boolean {
+  return typeof body.message === "string" && body.message.length > 0;
+}
+
+describe("POST /:id/messages — body validation", () => {
+  it("accepts a non-empty string message field", () => {
+    expect(validateSendMessage({ message: "Hello!" })).toBe(true);
+  });
+
+  it("rejects when message field is missing", () => {
+    expect(validateSendMessage({})).toBe(false);
+  });
+
+  it("rejects when message is a number (wrong type)", () => {
+    expect(validateSendMessage({ message: 42 })).toBe(false);
+  });
+
+  it("rejects when message is null", () => {
+    expect(validateSendMessage({ message: null })).toBe(false);
+  });
+
+  it("rejects empty string message", () => {
+    expect(validateSendMessage({ message: "" })).toBe(false);
+  });
+
+  it("rejects a 'content' field (old field name that caused the bug)", () => {
+    // The UI previously sent { content, role: "user" } which the server ignored.
+    // The correct field is 'message'. This test documents the contract.
+    const body = { content: "Hello!", role: "user" } as { message?: unknown };
+    expect(validateSendMessage(body)).toBe(false);
+  });
+});
+
+// ── GET /conversations — lastMessage and messageCount fields ───────
+//
+// The route was updated to include correlated subqueries for lastMessage and
+// messageCount. Verify the expected keys are present in the response shape.
+
+describe("GET /conversations — response shape", () => {
+  it("response includes lastMessage field (null for empty conversations)", () => {
+    const row = {
+      id: "conv-1",
+      agentId: "agent-1",
+      memberId: "member-1",
+      channel: "web",
+      lastMessage: null as string | null,
+      messageCount: 0,
+    };
+    expect("lastMessage" in row).toBe(true);
+    expect(row.lastMessage).toBeNull();
+  });
+
+  it("response includes messageCount field defaulting to 0", () => {
+    const row = {
+      id: "conv-1",
+      messageCount: 0,
+    };
+    expect(row.messageCount).toBe(0);
+  });
+
+  it("lastMessage is a string when messages exist", () => {
+    const row = { lastMessage: "Let me check that for you." };
+    expect(typeof row.lastMessage).toBe("string");
+    expect(row.lastMessage.length).toBeGreaterThan(0);
+  });
+});

--- a/server/src/routes/conversations.ts
+++ b/server/src/routes/conversations.ts
@@ -164,19 +164,32 @@ export function createConversationRoutes(
     // Use the memberId from the conversation if not provided
     const effectiveMemberId = memberId ?? conversation.memberId;
 
+    // SSE — headers must be committed before any write
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache");
+    res.setHeader("Connection", "keep-alive");
+    res.flushHeaders();
+
+    let closed = false;
+    req.on("close", () => { closed = true; });
+
     const result = await constitutionEngine.processMessage({
       agentId: conversation.agentId,
       memberId: effectiveMemberId,
       householdId: conversation.householdId,
       message,
       channel: "web",
+      onTextDelta: (text) => {
+        if (!closed) {
+          res.write(`data: ${JSON.stringify({ type: "delta", text })}\n\n`);
+        }
+      },
     });
 
-    res.json({
-      response: result.response,
-      blocked: result.blocked,
-      policyEvents: result.policyEvents,
-    });
+    if (!closed) {
+      res.write(`data: ${JSON.stringify({ type: "done", blocked: result.blocked, policyEvents: result.policyEvents })}\n\n`);
+      res.end();
+    }
   });
 
   return router;

--- a/server/src/services/__tests__/auth.test.ts
+++ b/server/src/services/__tests__/auth.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for API authentication: token format, generation behaviour,
+ * and middleware exemption/authorization logic.
+ *
+ * getOrCreateDashboardToken() is tested via a mock DB inline below.
+ * The middleware logic is tested against extracted predicates — it's
+ * simple string comparison, but the exemption rules are security-critical.
+ *
+ * NOTE: The getOrCreateDashboardToken import lives in server/src/services/auth.ts
+ * which is on the feat/api-auth branch. The mock-DB behaviour tests at the
+ * bottom of this file document the expected contract regardless of branch.
+ */
+
+import { describe, it, expect } from "vitest";
+import { randomBytes } from "node:crypto";
+
+// ── Token format invariants ────────────────────────────────────────
+
+describe("dashboard token format", () => {
+  it("randomBytes(32).toString('hex') produces a 64-char hex string", () => {
+    // This is the generation strategy used by getOrCreateDashboardToken.
+    // Verifying the shape here locks in the format so a future change
+    // (e.g. switching to base64url) requires an explicit test update.
+    const token = randomBytes(32).toString("hex");
+    expect(token).toHaveLength(64);
+    expect(/^[0-9a-f]{64}$/.test(token)).toBe(true);
+  });
+
+  it("generates a different token each call (sufficient entropy)", () => {
+    const tokens = new Set(
+      Array.from({ length: 20 }, () => randomBytes(32).toString("hex")),
+    );
+    expect(tokens.size).toBe(20);
+  });
+});
+
+// ── getOrCreateDashboardToken — contract via mock DB ──────────────
+//
+// We replicate the key observable behaviours without importing auth.ts
+// directly so this test file can live on any branch. When auth.ts is
+// present, the behaviour described here should match exactly.
+
+describe("getOrCreateDashboardToken (contract)", () => {
+  it("returns existing token without inserting a new one", async () => {
+    // Simulate: DB has a stored token → return it, call insert 0 times.
+    const storedToken = "a".repeat(64);
+    let insertCalled = false;
+
+    async function getOrCreate(existingValue: string | null): Promise<string> {
+      if (existingValue && typeof existingValue === "string" && existingValue.length > 0) {
+        return existingValue;
+      }
+      insertCalled = true;
+      return randomBytes(32).toString("hex");
+    }
+
+    const result = await getOrCreate(storedToken);
+    expect(result).toBe(storedToken);
+    expect(insertCalled).toBe(false);
+  });
+
+  it("generates and inserts a new token when DB has none", async () => {
+    let inserted: string | null = null;
+
+    async function getOrCreate(existingValue: string | null): Promise<string> {
+      if (existingValue && typeof existingValue === "string" && existingValue.length > 0) {
+        return existingValue;
+      }
+      const token = randomBytes(32).toString("hex");
+      inserted = token;
+      return token;
+    }
+
+    const result = await getOrCreate(null);
+    expect(result).toHaveLength(64);
+    expect(/^[0-9a-f]{64}$/.test(result)).toBe(true);
+    expect(inserted).toBe(result);
+  });
+
+  it("does not treat a non-string DB value as a valid token", async () => {
+    // instance_settings value is typed as json (unknown at runtime) —
+    // a number or object must not be returned as the token.
+    let insertCalled = false;
+
+    async function getOrCreate(existingValue: unknown): Promise<string> {
+      if (existingValue && typeof existingValue === "string" && existingValue.length > 0) {
+        return existingValue;
+      }
+      insertCalled = true;
+      return randomBytes(32).toString("hex");
+    }
+
+    await getOrCreate(12345);
+    expect(insertCalled).toBe(true);
+
+    insertCalled = false;
+    await getOrCreate({ token: "object" });
+    expect(insertCalled).toBe(true);
+  });
+
+  it("generates different tokens on independent fresh-DB calls", async () => {
+    async function freshToken(): Promise<string> {
+      return randomBytes(32).toString("hex");
+    }
+    const [t1, t2] = await Promise.all([freshToken(), freshToken()]);
+    expect(t1).not.toBe(t2);
+  });
+});
+
+// ── Middleware exemption rules ─────────────────────────────────────
+//
+// app.ts middleware logic:
+//   if (path === "/health" || path.startsWith("/health/")) → exempt
+//   if (path === "/bootstrap-token") → exempt
+//   else → require Bearer token
+
+function isExempt(path: string): boolean {
+  return (
+    path === "/health" ||
+    path.startsWith("/health/") ||
+    path === "/bootstrap-token"
+  );
+}
+
+describe("middleware exemption rules", () => {
+  it("/health is exempt", () => {
+    expect(isExempt("/health")).toBe(true);
+  });
+
+  it("/health/ subpaths are exempt (e.g. /health/db, /health/adapter)", () => {
+    expect(isExempt("/health/db")).toBe(true);
+    expect(isExempt("/health/adapter")).toBe(true);
+  });
+
+  it("/bootstrap-token is exempt", () => {
+    expect(isExempt("/bootstrap-token")).toBe(true);
+  });
+
+  it("all other paths are NOT exempt", () => {
+    const paths = ["/settings", "/conversations", "/staff", "/households", "/members", "/tools"];
+    for (const p of paths) {
+      expect(isExempt(p)).toBe(false);
+    }
+  });
+
+  it("does not exempt paths that merely start with 'health' (e.g. /healthcheck)", () => {
+    // startsWith("/health/") requires the slash, so /healthcheck is not exempt
+    expect(isExempt("/healthcheck")).toBe(false);
+  });
+
+  it("does not exempt /bootstrap-token/ with trailing slash", () => {
+    // Exact match only — /bootstrap-token/ is a different path
+    expect(isExempt("/bootstrap-token/")).toBe(false);
+  });
+});
+
+// ── Bearer token authorization check ──────────────────────────────
+
+function isAuthorized(authHeader: string | undefined, token: string): boolean {
+  return !!authHeader && authHeader === `Bearer ${token}`;
+}
+
+describe("bearer token authorization check", () => {
+  const token = randomBytes(32).toString("hex");
+
+  it("accepts correct Bearer token", () => {
+    expect(isAuthorized(`Bearer ${token}`, token)).toBe(true);
+  });
+
+  it("rejects missing Authorization header", () => {
+    expect(isAuthorized(undefined, token)).toBe(false);
+  });
+
+  it("rejects empty Authorization header", () => {
+    expect(isAuthorized("", token)).toBe(false);
+  });
+
+  it("rejects wrong token value", () => {
+    const other = randomBytes(32).toString("hex");
+    expect(isAuthorized(`Bearer ${other}`, token)).toBe(false);
+  });
+
+  it("rejects token sent without Bearer scheme prefix", () => {
+    expect(isAuthorized(token, token)).toBe(false);
+  });
+
+  it("rejects Basic scheme even with the correct token as the credential", () => {
+    expect(isAuthorized(`Basic ${token}`, token)).toBe(false);
+  });
+
+  it("is case-sensitive for the token value", () => {
+    expect(isAuthorized(`Bearer ${token.toUpperCase()}`, token)).toBe(false);
+  });
+
+  it("rejects 'Bearer ' with no token (trailing space only)", () => {
+    expect(isAuthorized("Bearer ", token)).toBe(false);
+  });
+});

--- a/server/src/services/__tests__/caldav-ical.test.ts
+++ b/server/src/services/__tests__/caldav-ical.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Tests for CalDAV iCal parsing helpers.
+ *
+ * These are the pure functions that convert raw iCalendar text from the
+ * CalDAV server into structured CalendarEvent objects. Real regressions here
+ * are silent data corruption — a broken parser returns wrong dates or drops
+ * events without throwing.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  parseAllVEvents,
+  parseICalDate,
+  decodeICalText,
+  encodeICalText,
+  foldLine,
+  type ParsedVEvent,
+} from "../caldav/caldav-provider.js";
+
+// ── parseICalDate ──────────────────────────────────────────────────
+
+describe("parseICalDate", () => {
+  it("parses an all-day date (YYYYMMDD) to ISO date string", () => {
+    expect(parseICalDate("20260415")).toBe("2026-04-15");
+  });
+
+  it("parses a UTC datetime (YYYYMMDDTHHmmssZ) to ISO 8601", () => {
+    const result = parseICalDate("20260415T140000Z");
+    expect(result).toBe("2026-04-15T14:00:00.000Z");
+  });
+
+  it("parses a floating datetime (no timezone suffix) verbatim", () => {
+    // Floating datetimes have no UTC marker — return without Z
+    expect(parseICalDate("20260415T140000")).toBe("2026-04-15T14:00:00");
+  });
+
+  it("returns unrecognised values as-is", () => {
+    expect(parseICalDate("not-a-date")).toBe("not-a-date");
+    expect(parseICalDate("")).toBe("");
+  });
+
+  it("handles midnight UTC correctly (not shifted to previous day)", () => {
+    const result = parseICalDate("20260101T000000Z");
+    expect(result).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("handles end-of-day UTC (23:59:59Z)", () => {
+    const result = parseICalDate("20261231T235959Z");
+    expect(result).toBe("2026-12-31T23:59:59.000Z");
+  });
+});
+
+// ── decodeICalText ─────────────────────────────────────────────────
+
+describe("decodeICalText", () => {
+  it("decodes \\n escape to newline", () => {
+    expect(decodeICalText("line one\\nline two")).toBe("line one\nline two");
+  });
+
+  it("decodes \\N (uppercase) as well", () => {
+    expect(decodeICalText("line one\\Nline two")).toBe("line one\nline two");
+  });
+
+  it("decodes \\, to literal comma", () => {
+    expect(decodeICalText("apples\\, oranges")).toBe("apples, oranges");
+  });
+
+  it("decodes \\; to literal semicolon", () => {
+    expect(decodeICalText("part one\\; part two")).toBe("part one; part two");
+  });
+
+  it("decodes \\\\ to single backslash", () => {
+    expect(decodeICalText("C:\\\\Users\\\\test")).toBe("C:\\Users\\test");
+  });
+
+  it("decodes multiple escape sequences in one string", () => {
+    const input = "Meeting\\, Board Room\\nBring ID\\; badge";
+    expect(decodeICalText(input)).toBe("Meeting, Board Room\nBring ID; badge");
+  });
+
+  it("leaves plain text unchanged", () => {
+    expect(decodeICalText("Weekly standup")).toBe("Weekly standup");
+  });
+
+  it("handles empty string", () => {
+    expect(decodeICalText("")).toBe("");
+  });
+});
+
+// ── encodeICalText ─────────────────────────────────────────────────
+
+describe("encodeICalText", () => {
+  it("encodes backslash first (avoids double-escaping)", () => {
+    expect(encodeICalText("C:\\Users\\test")).toBe("C:\\\\Users\\\\test");
+  });
+
+  it("encodes semicolons", () => {
+    expect(encodeICalText("part one; part two")).toBe("part one\\; part two");
+  });
+
+  it("encodes commas", () => {
+    expect(encodeICalText("apples, oranges")).toBe("apples\\, oranges");
+  });
+
+  it("encodes newlines", () => {
+    expect(encodeICalText("line one\nline two")).toBe("line one\\nline two");
+  });
+
+  it("is the inverse of decodeICalText for round-trip", () => {
+    const original = "Meeting, Board Room\nBring ID; badge";
+    expect(decodeICalText(encodeICalText(original))).toBe(original);
+  });
+
+  it("handles empty string", () => {
+    expect(encodeICalText("")).toBe("");
+  });
+});
+
+// ── foldLine ───────────────────────────────────────────────────────
+
+describe("foldLine (RFC 5545 §3.1 line folding)", () => {
+  it("leaves lines at or under 75 chars unchanged", () => {
+    const short = "SUMMARY:Team standup";
+    expect(foldLine(short)).toBe(short);
+
+    const exactly75 = "X".repeat(75);
+    expect(foldLine(exactly75)).toBe(exactly75);
+  });
+
+  it("folds a 76-char line at position 75 with CRLF + space", () => {
+    const line = "A".repeat(76);
+    const folded = foldLine(line);
+    expect(folded).toContain("\r\n ");
+    // First chunk is exactly 75 chars
+    const parts = folded.split("\r\n");
+    expect(parts[0]).toHaveLength(75);
+    // Continuation chunk starts with a space, holds the remaining char
+    expect(parts[1]).toBe(" " + "A");
+  });
+
+  it("folds multiple times for very long lines", () => {
+    const line = "DESCRIPTION:" + "X".repeat(300);
+    const folded = foldLine(line);
+    const parts = folded.split("\r\n");
+    // First chunk ≤ 75, all continuation chunks ≤ 75 (74 content + 1 leading space)
+    for (const part of parts) {
+      expect(part.length).toBeLessThanOrEqual(75);
+    }
+    // Reassembling (strip leading spaces from continuations) should give back original
+    const rejoined = parts[0] + parts.slice(1).map((p) => p.slice(1)).join("");
+    expect(rejoined).toBe(line);
+  });
+
+  it("handles a line of exactly 149 chars (fits in exactly two chunks)", () => {
+    // 75 first + 74 continuation = 149 chars total
+    const line = "B".repeat(149);
+    const folded = foldLine(line);
+    const parts = folded.split("\r\n");
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toHaveLength(75);
+    expect(parts[1]).toBe(" " + "B".repeat(74));
+  });
+});
+
+// ── parseAllVEvents ────────────────────────────────────────────────
+
+describe("parseAllVEvents", () => {
+  const wrap = (veventContent: string) =>
+    `BEGIN:VCALENDAR\r\nVERSION:2.0\r\n${veventContent}END:VCALENDAR\r\n`;
+
+  const singleEvent = wrap(
+    "BEGIN:VEVENT\r\n" +
+    "DTSTART:20260415T140000Z\r\n" +
+    "DTEND:20260415T150000Z\r\n" +
+    "SUMMARY:Team standup\r\n" +
+    "LOCATION:Zoom\r\n" +
+    "DESCRIPTION:Weekly sync\r\n" +
+    "END:VEVENT\r\n",
+  );
+
+  it("parses a single VEVENT block", () => {
+    const result = parseAllVEvents(singleEvent);
+    expect(result).toHaveLength(1);
+    expect(result[0].summary).toBe("Team standup");
+    expect(result[0].location).toBe("Zoom");
+    expect(result[0].description).toBe("Weekly sync");
+  });
+
+  it("preserves rawDtstart for occurrence ID construction", () => {
+    const result = parseAllVEvents(singleEvent);
+    expect(result[0].rawDtstart).toBe("20260415T140000Z");
+  });
+
+  it("parses start and end as ISO strings", () => {
+    const result = parseAllVEvents(singleEvent);
+    expect(result[0].start).toBe("2026-04-15T14:00:00.000Z");
+    expect(result[0].end).toBe("2026-04-15T15:00:00.000Z");
+  });
+
+  it("parses multiple VEVENT blocks (server-expanded recurring events)", () => {
+    const ical = wrap(
+      "BEGIN:VEVENT\r\nDTSTART:20260415T140000Z\r\nDTEND:20260415T150000Z\r\nSUMMARY:Standup 1\r\nEND:VEVENT\r\n" +
+      "BEGIN:VEVENT\r\nDTSTART:20260422T140000Z\r\nDTEND:20260422T150000Z\r\nSUMMARY:Standup 2\r\nEND:VEVENT\r\n" +
+      "BEGIN:VEVENT\r\nDTSTART:20260429T140000Z\r\nDTEND:20260429T150000Z\r\nSUMMARY:Standup 3\r\nEND:VEVENT\r\n",
+    );
+    const result = parseAllVEvents(ical);
+    expect(result).toHaveLength(3);
+    expect(result.map((v) => v.summary)).toEqual(["Standup 1", "Standup 2", "Standup 3"]);
+  });
+
+  it("captures RECURRENCE-ID on exception instances", () => {
+    const ical = wrap(
+      "BEGIN:VEVENT\r\nDTSTART:20260415T140000Z\r\nDTEND:20260415T150000Z\r\n" +
+      "RECURRENCE-ID:20260415T140000Z\r\nSUMMARY:Override occurrence\r\nEND:VEVENT\r\n",
+    );
+    const result = parseAllVEvents(ical);
+    expect(result).toHaveLength(1);
+    expect(result[0].recurrenceId).toBe("20260415T140000Z");
+  });
+
+  it("master VEVENT (no RECURRENCE-ID) has recurrenceId undefined", () => {
+    const result = parseAllVEvents(singleEvent);
+    expect(result[0].recurrenceId).toBeUndefined();
+  });
+
+  it("skips VEVENT blocks without DTSTART", () => {
+    const ical = wrap(
+      "BEGIN:VEVENT\r\nSUMMARY:No start date\r\nEND:VEVENT\r\n",
+    );
+    expect(parseAllVEvents(ical)).toHaveLength(0);
+  });
+
+  it("handles LF-only line endings (not just CRLF)", () => {
+    const ical =
+      "BEGIN:VCALENDAR\n" +
+      "BEGIN:VEVENT\n" +
+      "DTSTART:20260415T140000Z\n" +
+      "SUMMARY:LF event\n" +
+      "END:VEVENT\n" +
+      "END:VCALENDAR\n";
+    const result = parseAllVEvents(ical);
+    expect(result).toHaveLength(1);
+    expect(result[0].summary).toBe("LF event");
+  });
+
+  it("unfolds RFC 5545 continuation lines before parsing", () => {
+    // A SUMMARY folded across two lines with CRLF + space
+    const ical =
+      "BEGIN:VCALENDAR\r\n" +
+      "BEGIN:VEVENT\r\n" +
+      "DTSTART:20260415T140000Z\r\n" +
+      "SUMMARY:This is a very long summary that has been folded\r\n" +
+      " across two lines\r\n" +
+      "END:VEVENT\r\n" +
+      "END:VCALENDAR\r\n";
+    const result = parseAllVEvents(ical);
+    expect(result).toHaveLength(1);
+    expect(result[0].summary).toBe(
+      "This is a very long summary that has been foldedacross two lines",
+    );
+  });
+
+  it("strips parameter suffix from property name (DTSTART;TZID=...)", () => {
+    // Properties with parameters like DTSTART;TZID=America/Chicago:20260415T090000
+    // must be captured under the bare "DTSTART" key.
+    const ical = wrap(
+      "BEGIN:VEVENT\r\n" +
+      "DTSTART;TZID=America/Chicago:20260415T090000\r\n" +
+      "DTEND;TZID=America/Chicago:20260415T100000\r\n" +
+      "SUMMARY:Zoned event\r\n" +
+      "END:VEVENT\r\n",
+    );
+    const result = parseAllVEvents(ical);
+    expect(result).toHaveLength(1);
+    // rawDtstart should be the value portion only
+    expect(result[0].rawDtstart).toBe("20260415T090000");
+  });
+
+  it("decodes iCal text escapes in summary and description", () => {
+    const ical = wrap(
+      "BEGIN:VEVENT\r\n" +
+      "DTSTART:20260415T140000Z\r\n" +
+      "SUMMARY:Board meeting\\, Q2 review\r\n" +
+      "DESCRIPTION:Agenda:\\n1. Budget\\n2. Roadmap\r\n" +
+      "END:VEVENT\r\n",
+    );
+    const result = parseAllVEvents(ical);
+    expect(result[0].summary).toBe("Board meeting, Q2 review");
+    expect(result[0].description).toBe("Agenda:\n1. Budget\n2. Roadmap");
+  });
+
+  it("returns empty array for an empty VCALENDAR", () => {
+    expect(parseAllVEvents("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n")).toHaveLength(0);
+    expect(parseAllVEvents("")).toHaveLength(0);
+  });
+
+  it("parses an all-day event (DTSTART as YYYYMMDD date)", () => {
+    const ical = wrap(
+      "BEGIN:VEVENT\r\n" +
+      "DTSTART:20260415\r\n" +
+      "DTEND:20260416\r\n" +
+      "SUMMARY:All day event\r\n" +
+      "END:VEVENT\r\n",
+    );
+    const result = parseAllVEvents(ical);
+    expect(result).toHaveLength(1);
+    expect(result[0].start).toBe("2026-04-15");
+    expect(result[0].end).toBe("2026-04-16");
+  });
+});

--- a/server/src/services/__tests__/imap-search.test.ts
+++ b/server/src/services/__tests__/imap-search.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Tests for IMAP helper functions: search query parser, message ID parser,
+ * and address formatter.
+ *
+ * These are pure functions. Regressions here mean agents silently search
+ * the wrong mailbox, use wrong date ranges, or mis-identify senders.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  parseSearchQuery,
+  parseMessageId,
+  formatAddresses,
+} from "../imap/imap-provider.js";
+
+// ── parseSearchQuery ───────────────────────────────────────────────
+
+describe("parseSearchQuery", () => {
+  it("parses from: operator", () => {
+    const result = parseSearchQuery("from:alice@example.com");
+    expect(result.from).toBe("alice@example.com");
+  });
+
+  it("parses to: operator", () => {
+    const result = parseSearchQuery("to:bob@example.com");
+    expect(result.to).toBe("bob@example.com");
+  });
+
+  it("parses cc: operator", () => {
+    const result = parseSearchQuery("cc:carol@example.com");
+    expect(result.cc).toBe("carol@example.com");
+  });
+
+  it("parses subject: operator", () => {
+    const result = parseSearchQuery("subject:quarterly");
+    expect(result.subject).toBe("quarterly");
+  });
+
+  it("parses body: operator", () => {
+    const result = parseSearchQuery("body:invoice");
+    expect(result.body).toBe("invoice");
+  });
+
+  it("parses is:unread as seen=false", () => {
+    const result = parseSearchQuery("is:unread");
+    expect(result.seen).toBe(false);
+  });
+
+  it("parses is:read as seen=true", () => {
+    const result = parseSearchQuery("is:read");
+    expect(result.seen).toBe(true);
+  });
+
+  it("parses is:flagged as flagged=true", () => {
+    const result = parseSearchQuery("is:flagged");
+    expect(result.flagged).toBe(true);
+  });
+
+  it("parses is:unflagged as flagged=false", () => {
+    const result = parseSearchQuery("is:unflagged");
+    expect(result.flagged).toBe(false);
+  });
+
+  it("parses is:answered as answered=true", () => {
+    const result = parseSearchQuery("is:answered");
+    expect(result.answered).toBe(true);
+  });
+
+  it("parses after: as since (date object)", () => {
+    const result = parseSearchQuery("after:2026-01-01");
+    expect(result.since).toBeInstanceOf(Date);
+    // Use getUTCFullYear so the test passes in all timezones (new Date("YYYY-MM-DD") is midnight UTC)
+    expect(result.since!.getUTCFullYear()).toBe(2026);
+  });
+
+  it("parses since: as alias for after:", () => {
+    const result = parseSearchQuery("since:2026-03-15");
+    expect(result.since).toBeInstanceOf(Date);
+  });
+
+  it("parses before: as Date object", () => {
+    const result = parseSearchQuery("before:2026-06-30");
+    expect(result.before).toBeInstanceOf(Date);
+    expect(result.before!.getUTCFullYear()).toBe(2026);
+  });
+
+  it("treats unrecognised tokens as full-text search", () => {
+    const result = parseSearchQuery("budget proposal");
+    expect(result.text).toBe("budget proposal");
+    expect(result.from).toBeUndefined();
+  });
+
+  it("appends multiple unrecognised tokens into a single text value", () => {
+    const result = parseSearchQuery("hello world foo");
+    expect(result.text).toBe("hello world foo");
+  });
+
+  it("combines known operators and free text in one query", () => {
+    const result = parseSearchQuery("from:alice@example.com is:unread invoice Q2");
+    expect(result.from).toBe("alice@example.com");
+    expect(result.seen).toBe(false);
+    expect(result.text).toBe("invoice Q2");
+  });
+
+  it("defaults to all:true when query is empty", () => {
+    expect(parseSearchQuery("").all).toBe(true);
+    expect(parseSearchQuery("   ").all).toBe(true);
+  });
+
+  it("does not set all:true when at least one criterion is present", () => {
+    const result = parseSearchQuery("from:alice@example.com");
+    expect(result.all).toBeUndefined();
+  });
+
+  it("strips surrounding double quotes from operator values", () => {
+    // subject:"quarterly review" → subject should be 'quarterly review'
+    const result = parseSearchQuery('subject:"quarterly review"');
+    expect(result.subject).toBe("quarterly review");
+  });
+
+  it("unknown is: values are silently ignored (no crash)", () => {
+    // Ensures we don't throw on new/unrecognised is: flags
+    expect(() => parseSearchQuery("is:spam")).not.toThrow();
+  });
+
+  it("operator names are case-insensitive (FROM: works)", () => {
+    const result = parseSearchQuery("FROM:alice@example.com");
+    expect(result.from).toBe("alice@example.com");
+  });
+});
+
+// ── parseMessageId ─────────────────────────────────────────────────
+
+describe("parseMessageId", () => {
+  it("parses INBOX:12345 correctly", () => {
+    const { mailbox, uid } = parseMessageId("INBOX:12345");
+    expect(mailbox).toBe("INBOX");
+    expect(uid).toBe(12345);
+  });
+
+  it("parses a nested mailbox name (Sent/2023)", () => {
+    // Mailbox names can contain slashes — only the last colon is the separator
+    const { mailbox, uid } = parseMessageId("Sent/2023:999");
+    expect(mailbox).toBe("Sent/2023");
+    expect(uid).toBe(999);
+  });
+
+  it("parses a mailbox name with colons (Trash:42)", () => {
+    // lastIndexOf(':') is the separator, earlier colons belong to mailbox name
+    const { mailbox, uid } = parseMessageId("Archive:Old:42");
+    expect(mailbox).toBe("Archive:Old");
+    expect(uid).toBe(42);
+  });
+
+  it("throws on missing colon separator", () => {
+    expect(() => parseMessageId("INBOX12345")).toThrow("Invalid message ID format");
+  });
+
+  it("throws on non-numeric UID", () => {
+    expect(() => parseMessageId("INBOX:abc")).toThrow("Invalid UID");
+  });
+
+  it("defaults mailbox to INBOX when part before colon is empty", () => {
+    const { mailbox } = parseMessageId(":5678");
+    expect(mailbox).toBe("INBOX");
+  });
+
+  it("returns uid as a number (not a string)", () => {
+    const { uid } = parseMessageId("INBOX:100");
+    expect(typeof uid).toBe("number");
+  });
+});
+
+// ── formatAddresses ────────────────────────────────────────────────
+
+describe("formatAddresses", () => {
+  it("formats name + address as 'Name <email>'", () => {
+    const result = formatAddresses([{ name: "Alice Smith", address: "alice@example.com" }]);
+    expect(result).toBe("Alice Smith <alice@example.com>");
+  });
+
+  it("formats address-only entry (no name)", () => {
+    const result = formatAddresses([{ address: "bob@example.com" }]);
+    expect(result).toBe("bob@example.com");
+  });
+
+  it("formats name-only entry (no address)", () => {
+    const result = formatAddresses([{ name: "No Address" }]);
+    expect(result).toBe("No Address");
+  });
+
+  it("joins multiple addresses with ', '", () => {
+    const result = formatAddresses([
+      { name: "Alice", address: "alice@example.com" },
+      { address: "bob@example.com" },
+    ]);
+    expect(result).toBe("Alice <alice@example.com>, bob@example.com");
+  });
+
+  it("returns empty string for undefined input", () => {
+    expect(formatAddresses(undefined)).toBe("");
+  });
+
+  it("returns empty string for empty array", () => {
+    expect(formatAddresses([])).toBe("");
+  });
+
+  it("handles entries where both name and address are missing", () => {
+    // Should not crash — returns empty string for that slot
+    const result = formatAddresses([{}]);
+    expect(result).toBe("");
+  });
+});

--- a/server/src/services/__tests__/imap-search.test.ts
+++ b/server/src/services/__tests__/imap-search.test.ts
@@ -70,7 +70,7 @@ describe("parseSearchQuery", () => {
     const result = parseSearchQuery("after:2026-01-01");
     expect(result.since).toBeInstanceOf(Date);
     // Use getUTCFullYear so the test passes in all timezones (new Date("YYYY-MM-DD") is midnight UTC)
-    expect(result.since!.getUTCFullYear()).toBe(2026);
+    expect((result.since as Date).getUTCFullYear()).toBe(2026);
   });
 
   it("parses since: as alias for after:", () => {
@@ -81,7 +81,7 @@ describe("parseSearchQuery", () => {
   it("parses before: as Date object", () => {
     const result = parseSearchQuery("before:2026-06-30");
     expect(result.before).toBeInstanceOf(Date);
-    expect(result.before!.getUTCFullYear()).toBe(2026);
+    expect((result.before as Date).getUTCFullYear()).toBe(2026);
   });
 
   it("treats unrecognised tokens as full-text search", () => {

--- a/server/src/services/caldav/caldav-provider.ts
+++ b/server/src/services/caldav/caldav-provider.ts
@@ -32,7 +32,7 @@ export interface CalDavAuthStatus {
 }
 
 /** A single parsed VEVENT block, used internally before building CalendarEvent. */
-interface ParsedVEvent {
+export interface ParsedVEvent {
   /** Raw iCal DTSTART value (e.g. "20260415T140000Z") — used as the occurrence ID fragment. */
   rawDtstart: string;
   /** Raw RECURRENCE-ID value, present only on exception/override instances. */
@@ -394,7 +394,7 @@ function getCalendarName(cal: DAVCalendar): string {
  *
  * Handles CRLF/LF line endings and RFC 5545 line folding (continuation lines).
  */
-function parseAllVEvents(ical: string): ParsedVEvent[] {
+export function parseAllVEvents(ical: string): ParsedVEvent[] {
   // Unfold: CRLF/LF followed by whitespace is a continuation
   const unfolded = ical.replace(/\r\n[ \t]/g, "").replace(/\n[ \t]/g, "");
   const lines = unfolded.split(/\r\n|\n/);
@@ -447,7 +447,7 @@ function parseAllVEvents(ical: string): ParsedVEvent[] {
 }
 
 /** Convert an iCal date/datetime value to an ISO 8601 string. */
-function parseICalDate(value: string): string {
+export function parseICalDate(value: string): string {
   // All-day: YYYYMMDD
   if (/^\d{8}$/.test(value)) {
     return `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`;
@@ -471,7 +471,7 @@ function parseICalDate(value: string): string {
 }
 
 /** Decode iCal text escaping (\\n → newline, \\, → comma, etc.). */
-function decodeICalText(value: string): string {
+export function decodeICalText(value: string): string {
   return value
     .replace(/\\n/gi, "\n")
     .replace(/\\,/g, ",")
@@ -480,7 +480,7 @@ function decodeICalText(value: string): string {
 }
 
 /** Encode a plain string for use as an iCal text property value. */
-function encodeICalText(value: string): string {
+export function encodeICalText(value: string): string {
   return value
     .replace(/\\/g, "\\\\")
     .replace(/;/g, "\\;")
@@ -535,7 +535,7 @@ function buildVEvent(opts: {
  * Fold a single iCal content line at 75 octets (RFC 5545 §3.1).
  * Continuation lines begin with a single space.
  */
-function foldLine(line: string): string {
+export function foldLine(line: string): string {
   if (line.length <= 75) return line;
   const chunks: string[] = [];
   chunks.push(line.slice(0, 75));

--- a/server/src/services/imap/imap-provider.ts
+++ b/server/src/services/imap/imap-provider.ts
@@ -283,7 +283,7 @@ async function fetchEnvelopes(
 // ── Message ID helpers ─────────────────────────────────────────────
 
 /** Parse a message ID in format "<mailbox>:<uid>". */
-function parseMessageId(messageId: string): { mailbox: string; uid: number } {
+export function parseMessageId(messageId: string): { mailbox: string; uid: number } {
   const colonIdx = messageId.lastIndexOf(":");
   if (colonIdx < 0) {
     throw new Error(
@@ -299,7 +299,7 @@ function parseMessageId(messageId: string): { mailbox: string; uid: number } {
 }
 
 /** Format an array of address objects to a readable string. */
-function formatAddresses(
+export function formatAddresses(
   addrs?: Array<{ name?: string; address?: string }>,
 ): string {
   if (!addrs || addrs.length === 0) return "";
@@ -496,6 +496,8 @@ function stripHtml(html: string): string {
 /**
  * Parse a Gmail-style search query string into an imapflow SearchObject.
  *
+ * Exported for unit testing.
+ *
  * Supported operators:
  *   from:address     — sender matches
  *   to:address       — recipient matches
@@ -512,7 +514,7 @@ function stripHtml(html: string): string {
  *
  * Unrecognised tokens are combined into a full-text search.
  */
-function parseSearchQuery(query: string): SearchObject {
+export function parseSearchQuery(query: string): SearchObject {
   const tokens = tokenize(query);
   const obj: SearchObject = {};
   const textParts: string[] = [];

--- a/ui/src/pages/Conversations.tsx
+++ b/ui/src/pages/Conversations.tsx
@@ -260,6 +260,9 @@ export function ConversationsPage() {
   const [staffFilter, setStaffFilter] = useState("all");
   const [messageInput, setMessageInput] = useState("");
   const [pendingUserMsg, setPendingUserMsg] = useState<string | null>(null);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [streamingContent, setStreamingContent] = useState<string | null>(null);
+  const streamAbortRef = useRef<AbortController | null>(null);
   const [showNewChat, setShowNewChat] = useState(false);
   const [newChatMember, setNewChatMember] = useState("");
   const [newChatAgent, setNewChatAgent] = useState("");
@@ -304,25 +307,6 @@ export function ConversationsPage() {
     queryKey: ["messages", selectedId],
     queryFn: () => api.get(`/conversations/${selectedId}/messages`),
     enabled: !!selectedId,
-  });
-
-  // Send message mutation — optimistic send with typing bubble
-  const sendMutation = useMutation({
-    mutationFn: (content: string) =>
-      api.post(`/conversations/${selectedId}/messages`, { message: content }),
-    onMutate: (content: string) => {
-      setPendingUserMsg(content);
-      setMessageInput("");
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["messages", selectedId] });
-      queryClient.invalidateQueries({ queryKey: ["conversations"] });
-    },
-    onError: (_err, content) => {
-      // Restore the message so the user can try again
-      setMessageInput(content);
-      setPendingUserMsg(null);
-    },
   });
 
   // Clear optimistic message once the real message lands
@@ -372,20 +356,80 @@ export function ConversationsPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Auto-scroll to bottom when messages or pending msg changes
+  // Auto-scroll to bottom when messages or streaming content changes
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messagesData, pendingUserMsg, sendMutation.isPending]);
+  }, [messagesData, pendingUserMsg, streamingContent]);
 
   const conversations = convsData?.conversations || [];
   const members = householdData?.members || [];
   const staff = staffData?.staff || [];
   const selectedConv = conversations.find((c) => c.id === selectedId);
 
-  function handleSend(e: React.FormEvent) {
+  async function handleSend(e: React.FormEvent) {
     e.preventDefault();
-    if (!messageInput.trim() || !selectedId || sendMutation.isPending) return;
-    sendMutation.mutate(messageInput.trim());
+    if (!messageInput.trim() || !selectedId || isStreaming) return;
+
+    const content = messageInput.trim();
+    setPendingUserMsg(content);
+    setMessageInput("");
+    setIsStreaming(true);
+    setStreamingContent("");
+
+    const abort = new AbortController();
+    streamAbortRef.current = abort;
+
+    try {
+      const token = localStorage.getItem("dashboard_token");
+      const res = await fetch(`/api/conversations/${selectedId}/messages`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ message: content }),
+        signal: abort.signal,
+      });
+
+      if (!res.ok || !res.body) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let accumulated = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        const chunk = decoder.decode(value, { stream: true });
+        for (const line of chunk.split("\n")) {
+          if (!line.startsWith("data: ")) continue;
+          try {
+            const event = JSON.parse(line.slice(6)) as { type: string; text?: string };
+            if (event.type === "delta" && event.text) {
+              accumulated += event.text;
+              setStreamingContent(accumulated);
+            } else if (event.type === "done") {
+              setStreamingContent(null);
+              setPendingUserMsg(null);
+              setIsStreaming(false);
+              queryClient.invalidateQueries({ queryKey: ["messages", selectedId] });
+              queryClient.invalidateQueries({ queryKey: ["conversations"] });
+            }
+          } catch {
+            // skip malformed frames
+          }
+        }
+      }
+    } catch (err) {
+      if ((err as { name?: string }).name !== "AbortError") {
+        setMessageInput(content);
+        setPendingUserMsg(null);
+      }
+      setStreamingContent(null);
+      setIsStreaming(false);
+    }
   }
 
   function handleNewChat(e: React.FormEvent) {
@@ -603,8 +647,22 @@ export function ConversationsPage() {
                     }}
                   />
                 )}
-                {/* Typing indicator while awaiting response */}
-                {sendMutation.isPending && <TypingBubble />}
+                {/* Streaming assistant response */}
+                {streamingContent !== null && (
+                  streamingContent === "" ? (
+                    <TypingBubble />
+                  ) : (
+                    <MessageBubble
+                      message={{
+                        id: "__streaming__",
+                        conversationId: selectedId,
+                        role: "assistant",
+                        content: streamingContent,
+                        createdAt: new Date().toISOString(),
+                      }}
+                    />
+                  )
+                )}
                 <div ref={messagesEndRef} />
               </div>
 
@@ -620,12 +678,12 @@ export function ConversationsPage() {
                   placeholder="Type a message…"
                   className="flex-1 text-sm"
                   style={{ borderColor: "#ddd5c8" }}
-                  disabled={sendMutation.isPending}
+                  disabled={isStreaming}
                 />
                 <Button
                   type="submit"
                   size="sm"
-                  disabled={!messageInput.trim() || sendMutation.isPending}
+                  disabled={!messageInput.trim() || isStreaming}
                   style={{ background: "#1a1f2e", color: "#e8dfd0" }}
                 >
                   <Send className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary

Adds real-time streaming to the web chat interface. Responses now appear token-by-token as Claude generates them, rather than waiting for the full response before displaying anything.

## What changed

### Server (`server/src/routes/conversations.ts`)
- `POST /:id/messages` now responds with `text/event-stream` instead of JSON
- Passes `onTextDelta` to `processMessage()` — each token is sent as a `data: {"type":"delta","text":"..."}` SSE event
- Final `data: {"type":"done",...}` event carries `blocked` and `policyEvents` metadata
- Client disconnect handled via `req.on("close")` — stops writing if browser closes mid-stream
- 400/404 guards still return normal JSON errors (headers not yet set at that point)

### UI (`ui/src/pages/Conversations.tsx`)
- Replaced `useMutation` send handler with a plain `fetch` + `ReadableStream` reader
- `streamingContent` state accumulates tokens as `delta` events arrive
- Live `MessageBubble` renders as tokens stream in (replaces `TypingBubble` during streaming)
- On `done`: clears streaming state, invalidates queries so persisted messages reload
- `TypingBubble` still shown between send and first token arrival

## Notes

- `onTextDelta` already existed on `ProcessMessageParams` — zero changes to the constitution engine
- Tested on macOS — responses stream visibly token by token in the browser
- Builds on the web chat PR — depends on `feat/web-chat` being merged first