### PR TITLE
docs: document Signal transport, CalDAV, and IMAP integrations

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,7 +22,9 @@ The head agent (Chief of Staff) manages the household. Other agents are personal
 
 ## The Pipeline
 
-When a family member sends a message on Telegram, here's what happens:
+Messages arrive on one of two transports — Telegram or Signal — and are normalized before entering the shared pipeline. Telegram supports rich media (voice, photos, documents); the Signal transport (via signal-cli SSE) handles text and basic attachments.
+
+When a family member sends a message, here's what happens:
 
 ```
 Telegram update (text | voice | audio | photo | document | sticker | video)
@@ -211,6 +213,24 @@ Tools: `list_calendar_events`, `create_calendar_event`, `get_calendar_event`, `g
 
 Gmail uses a draft-first workflow: compose/reply create drafts, the user reviews in Gmail, then either sends from Gmail or tells the agent "send it."
 
+### CalDAV Integration
+
+CalDAV is an open protocol for calendar access. The CalDAV provider is an alternative to `gws` for families using iCloud Calendar, Fastmail, or any standards-compliant server.
+
+It handles VEVENT parsing with full RFC 5545 compliance: iCal text escaping and decoding, line folding and unfolding, all-day vs. UTC vs. floating datetime formats, RECURRENCE-ID for exception instances, and `DTSTART;TZID=` parameter stripping for timezone-qualified properties. Credentials are stored as JSON files in `~/.carsonos/caldav/<member>/`.
+
+### IMAP Integration
+
+The IMAP provider gives agents mailbox access without requiring Google. It uses `imapflow` and supports a Gmail-style search query syntax parsed at the provider layer before being translated to IMAP search criteria:
+
+- `from:`, `to:`, `cc:`, `subject:`, `body:` — field-scoped filters
+- `is:unread`, `is:read`, `is:flagged`, `is:answered` — flag filters
+- `before:`, `after:` / `since:` — date range filters
+- Unrecognised tokens become full-text search terms
+- Empty query defaults to `ALL`
+
+Message IDs use the format `MAILBOX:UID` (e.g. `INBOX:12345`), using the last colon as separator so mailbox names containing colons or slashes are handled correctly. Credentials are stored as JSON files in `~/.carsonos/imap/<member>/`.
+
 ## Constitution Engine
 
 The constitution is the frame. It goes first in every system prompt.
@@ -248,7 +268,7 @@ The profile interview collects information that becomes the member's profile, in
 - **Sub-agents** — Specialist agents (tutor, developer) that the Chief of Staff delegates to (delegation infra exists, disabled in v0.1+)
 - **Tool-call notifications** — Italicized status text in stream during tool execution ("*Searching calendar...*")
 - **Web UI chat** — Chat with agents from the dashboard (currently Telegram only)
-- **Signal / WhatsApp / Slack** — Other messaging platforms
+- **WhatsApp / Slack** — Additional messaging platforms beyond Telegram and Signal
 - **Inbound video understanding** — Videos are size-guarded and acknowledged; frame extraction / vision pass not yet wired
 
 ## Inspiration

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ CarsonOS is a self-hosted AI staff platform for families. Each family member get
 
 ## What You Get
 
-- **Personal agents** — Each family member gets their own AI on Telegram with a distinct personality
+- **Personal agents** — Each family member gets their own AI on Telegram or Signal with a distinct personality
 - **Memory that sticks** — Agents remember facts, preferences, events, and commitments across conversations
 - **Voice, audio, and photos** — Send a voice message and the agent transcribes it. Send a photo and the agent actually sees it. Audio file attachments work too.
-- **Calendar & email** — Check schedules, create events, draft emails (never sends without your OK)
+- **Calendar & email** — Check schedules, create events, draft emails. Works with Google Calendar / Gmail (via `gws`) and CalDAV / IMAP (iCloud, Fastmail, any standards-compliant server). Drafts are never sent without your OK.
 - **A constitution** — Your family's rules and values, enforced across every agent
 - **Trust levels** — A parent's agent has full system access; a 6-year-old's is locked down
 - **Everything local** — SQLite database, markdown memory files, no cloud dependencies
@@ -24,6 +24,7 @@ CarsonOS is a self-hosted AI staff platform for families. Each family member get
 | **pnpm** | `npm install -g pnpm` | Package manager (monorepo) |
 | **Claude CLI** | `npm install -g @anthropic-ai/claude-code` | Agent runtime (uses your Claude subscription) |
 | **QMD** | `npm install -g @tobilu/qmd` | Local markdown search engine for memory |
+| **signal-cli** | [github.com/AsamK/signal-cli](https://github.com/AsamK/signal-cli/releases) | Signal transport (optional) |
 
 Optional:
 - **gws** — `npm install -g googleworkspace/cli` — Google Workspace CLI (Calendar, Gmail, Drive)
@@ -56,7 +57,7 @@ Then open [http://localhost:3300/onboarding](http://localhost:3300/onboarding) a
 
 1. **Family** — Name your household and add family members (name, age, role)
 2. **Agent** — Create your first agent and optionally connect a Telegram bot
-3. **Done** — Open Telegram and start chatting
+3. **Done** — Open Telegram (or Signal) and start chatting
 
 <!-- TODO: Add onboarding screenshot -->
 
@@ -107,6 +108,17 @@ GOOGLE_WORKSPACE_CLI_CONFIG_DIR=~/.carsonos/google/your-name gws auth login
 ```
 
 Each family member authenticates separately with their own Google account.
+
+### Connecting Signal (optional)
+
+Signal transport uses `signal-cli` running as a local JSON-RPC daemon over HTTP/SSE:
+
+1. Install `signal-cli` and register your Signal number
+2. Start the daemon:
+   ```bash
+   signal-cli -a +1XXXXXXXXXX daemon --http localhost:8080
+   ```
+3. In the dashboard, go to Staff → your agent and enter the Signal number and daemon endpoint
 
 ## How It Works
 
@@ -175,9 +187,10 @@ Agents get tools based on their role and trust level:
 | `update_memory` | Update existing memory entries in-place |
 | `delete_memory` | Remove outdated memories |
 | `update_instructions` | Maintain operating instructions |
-| `list_calendar_events` | Check schedules (requires gws) |
-| `create_calendar_event` | Create events (requires gws) |
-| `gmail_*` | Read, draft, and manage email (requires gws) |
+| `list_calendar_events` | Check schedules (Google Calendar via gws, or any CalDAV server) |
+| `create_calendar_event` | Create events (Google Calendar via gws, or any CalDAV server) |
+| `gmail_*` | Read, draft, and manage email via Google (requires gws) |
+| `imap_*` | Read and search email via IMAP (iCloud, Fastmail, any standards-compliant server) |
 | `drive_*` | Search and list Drive files (requires gws) |
 | `create_http_tool` | Wrap any HTTPS API as a custom tool |
 | `create_prompt_tool` | Turn a recipe into an agent-invokable skill |
@@ -237,6 +250,9 @@ server/
       env-hydration.ts          <- Hydrate platform secrets from instance_settings → env
       memory/                   <- MemoryProvider, QMD provider, schema, tools
       google/                   <- Calendar, Gmail, Drive providers
+      caldav/                   <- CalDAV calendar provider (iCloud Calendar, Fastmail, etc.)
+      imap/                     <- IMAP email provider
+      signal/                   <- Signal transport (signal-cli SSE daemon)
 
 ui/
   src/


### PR DESCRIPTION
## Summary

Updates README.md and ARCHITECTURE.md to document the three integrations added in recent PRs (#22 Signal, #14 CalDAV, #15 IMAP). These features are merged but not yet reflected in the docs.

## README.md changes

- "Personal agents" bullet: Telegram → Telegram or Signal
- "Calendar & email" bullet: expanded to name Google Calendar/Gmail and CalDAV/IMAP as backends
- Prerequisites table: signal-cli row added (optional)
- Quick Start step 3: mentions Signal alongside Telegram
- New "Connecting Signal (optional)" section after "Connecting Google"
- Tools table: calendar tool rows updated, imap_* row added
- Project structure: caldav/, imap/, signal/ service directories added

## ARCHITECTURE.md changes

- Pipeline preamble: two-sentence note explaining Telegram and Signal as the two transports
- New "CalDAV Integration" section with credential path and RFC 5545 compliance notes
- New "IMAP Integration" section with Gmail-style query syntax and message ID format
- "What's Not Built Yet": Signal removed (it's built), WhatsApp/Slack kept

## Notes

- No structural changes — all additive or small updates within existing sections
- Credential paths reflect current implementation (~/.carsonos/caldav/ and ~/.carsonos/imap/)