### PR TITLE
feat: Planner v2 — architectural plan with accept gate

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -162,6 +162,8 @@ CREATE TABLE tasks (
   notify_payload TEXT,
   notified_at INTEGER,
   notify_agent_id TEXT REFERENCES staff_agents(id),
+  plan_status TEXT,
+  parent_plan_task_id TEXT,
   created_at INTEGER NOT NULL DEFAULT (unixepoch()),
   updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
   completed_at INTEGER
@@ -397,7 +399,9 @@ function upgradeTables(sqlite: Database.Database, preMigrationHook?: PreMigratio
     // v0.4 delegation
     !taskCols.has("project_id") || !taskCols.has("notify_payload") ||
     !taskCols.has("notify_agent_id") ||
-    !tableExists("projects") || !tableExists("delegation_notifications");
+    !tableExists("projects") || !tableExists("delegation_notifications") ||
+    // Planner v2
+    !taskCols.has("plan_status") || !taskCols.has("parent_plan_task_id");
 
   if (needsUpgrade && preMigrationHook) {
     preMigrationHook("schema-upgrade");
@@ -713,6 +717,20 @@ function upgradeTables(sqlite: Database.Database, preMigrationHook?: PreMigratio
       )`).run();
       sqlite.prepare("CREATE UNIQUE INDEX delegation_notifications_task_kind_unique ON delegation_notifications(task_id, kind)").run();
       sqlite.prepare("CREATE INDEX delegation_notifications_task_idx ON delegation_notifications(task_id)").run();
+      upgraded = true;
+    }
+
+    // Planner v2: tasks.plan_status + tasks.parent_plan_task_id. Both nullable
+    // because they only apply to Planner tasks; other specialties leave them
+    // null. parent_plan_task_id is a logical FK to tasks.id (self-ref) — kept
+    // un-enforced at the DB layer to match parent_task_id's pattern.
+    const taskColsPlanner = cols("tasks");
+    if (!taskColsPlanner.has("plan_status")) {
+      sqlite.prepare("ALTER TABLE tasks ADD COLUMN plan_status TEXT").run();
+      upgraded = true;
+    }
+    if (!taskColsPlanner.has("parent_plan_task_id")) {
+      sqlite.prepare("ALTER TABLE tasks ADD COLUMN parent_plan_task_id TEXT").run();
       upgraded = true;
     }
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -178,6 +178,12 @@ export const tasks = sqliteTable(
     notifyPayload: text("notify_payload", { mode: "json" }), // composed before send; flip-invariant with notified_at
     notifiedAt: integer("notified_at", { mode: "timestamp" }), // set only on successful delivery
     notifyAgentId: text("notify_agent_id").references(() => staffAgents.id), // completion routes here (kid's personal agent, not CoS)
+    // Planner v2: set automatically on Planner task completion when the plan
+    // parses successfully; mutated by accept_plan; gates Developer hires.
+    planStatus: text("plan_status").$type<
+      "pending_approval" | "accepted" | "revise" | "replan"
+    >(),
+    parentPlanTaskId: text("parent_plan_task_id"), // FK to tasks.id. NULL except on revision plans.
     createdAt: integer("created_at", { mode: "timestamp" }).notNull().default(nowEpoch),
     updatedAt: integer("updated_at", { mode: "timestamp" }).notNull().default(nowEpoch),
     completedAt: integer("completed_at", { mode: "timestamp" }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       grammy:
         specifier: ^1.35.0
         version: 1.42.0
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       imapflow:
         specifier: ^1.3.2
         version: 1.3.2
@@ -2025,6 +2028,9 @@ packages:
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
@@ -2446,6 +2452,11 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
@@ -2485,6 +2496,10 @@ packages:
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
+
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -2593,6 +2608,10 @@ packages:
     resolution: {integrity: sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g==}
     engines: {node: ^12.20.0 || >=14.13.1}
 
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -2665,6 +2684,10 @@ packages:
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2711,6 +2734,10 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -2730,6 +2757,10 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   libbase64@1.3.0:
     resolution: {integrity: sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==}
@@ -3301,6 +3332,10 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
@@ -3397,6 +3432,9 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -3412,6 +3450,10 @@ packages:
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -5164,6 +5206,10 @@ snapshots:
 
   arg@5.0.2: {}
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
@@ -5579,6 +5625,8 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  esprima@4.0.1: {}
+
   estree-util-is-identifier-name@3.0.0: {}
 
   estree-walker@3.0.3:
@@ -5636,6 +5684,10 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
 
   extend@3.0.2: {}
 
@@ -5752,6 +5804,13 @@ snapshots:
       - encoding
       - supports-color
 
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
   has-symbols@1.1.0: {}
 
   hasown@2.0.2:
@@ -5841,6 +5900,8 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
+  is-extendable@0.1.1: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
@@ -5869,6 +5930,11 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   jsesc@3.1.0: {}
 
   json-schema-to-ts@3.1.1:
@@ -5881,6 +5947,8 @@ snapshots:
   json-schema-typed@8.0.2: {}
 
   json5@2.2.3: {}
+
+  kind-of@6.0.3: {}
 
   libbase64@1.3.0: {}
 
@@ -6698,6 +6766,11 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   secure-json-parse@4.1.0: {}
 
   semver@6.3.1: {}
@@ -6834,6 +6907,8 @@ snapshots:
 
   split2@4.2.0: {}
 
+  sprintf-js@1.0.3: {}
+
   stackback@0.0.2: {}
 
   statuses@2.0.2: {}
@@ -6848,6 +6923,8 @@ snapshots:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-bom-string@1.0.0: {}
 
   strip-json-comments@2.0.1: {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
     "esbuild": "^0.28.0",
     "express": "^5.1.0",
     "grammy": "^1.35.0",
+    "gray-matter": "^4.0.3",
     "imapflow": "^1.3.2",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -465,21 +465,41 @@ async function main() {
           await multiRelay.editMessage(task.agentId, member.telegramUserId, notif.deliveredMessageId, stampedText).catch(() => {});
         }
 
-        // Pull originalUserRequest out of the hire-proposal metadata. If the
-        // proposer passed it, auto-delegate so the user doesn't have to
-        // re-prompt. If not (proactive hire), just tell the user the
-        // specialist is ready and wait.
+        // Pull originalUserRequest + planTaskId out of the hire-proposal
+        // metadata. If the proposer passed either, auto-delegate so the user
+        // doesn't have to re-prompt. Plan body (when present) becomes the
+        // authoritative brief; originalUserRequest is preserved as task
+        // context so the Developer sees what the user originally asked.
         let originalUserRequest: string | undefined;
+        let planTaskId: string | undefined;
         try {
           const meta = task.description ? JSON.parse(task.description) : null;
           if (meta && typeof meta.originalUserRequest === "string" && meta.originalUserRequest.trim()) {
             originalUserRequest = meta.originalUserRequest.trim();
           }
+          if (meta && typeof meta.planTaskId === "string" && meta.planTaskId.trim()) {
+            planTaskId = meta.planTaskId.trim();
+          }
         } catch {
           // malformed description — proceed as if no originalUserRequest
         }
 
-        if (!originalUserRequest) {
+        // Planner v2: when plan_task_id is set, load the plan body and use it
+        // as the auto-delegation brief. The plan is authoritative; the
+        // user's original ask rides along as task context for traceability.
+        let planBody: string | undefined;
+        if (planTaskId) {
+          const [planTask] = await db
+            .select({ result: tasksTable.result })
+            .from(tasksTable)
+            .where(eq(tasksTable.id, planTaskId))
+            .limit(1);
+          if (planTask?.result) {
+            planBody = planTask.result;
+          }
+        }
+
+        if (!originalUserRequest && !planBody) {
           const text =
             `✅ **${data.name}** is on staff — ${data.specialty} specialist.\n\n` +
             `Tell me what you want them to work on and I'll delegate it.`;
@@ -499,25 +519,47 @@ async function main() {
           return;
         }
 
-        // Auto-delegation path: run the original request through the
-        // delegation service as if the proposing agent had called
+        // Auto-delegation path: run the plan (if present) or original request
+        // through the delegation service as if the proposing agent had called
         // delegate_task directly. No LLM turn required; handleDelegateTaskCall
         // validates the edge (which we just created on approval), creates
         // the task row with correct depth + workspace kind, and hands it to
         // the dispatcher. User sees one concise status message, then the
         // specialist's completion notification when it finishes.
+        const goal = planBody ?? originalUserRequest!;
+        const delegationContext = planBody
+          ? [
+              originalUserRequest
+                ? `Original user request:\n${originalUserRequest}`
+                : null,
+              planTaskId ? `Authoritative plan from task ${planTaskId} (above).` : null,
+            ]
+              .filter((s): s is string => s !== null)
+              .join("\n\n")
+          : undefined;
+
         const delegated = await orchestrator.handleDelegateTaskCall({
           fromAgentId: task.agentId,
           householdId: data.householdId,
           toAgentName: data.name,
-          goal: originalUserRequest,
+          goal,
+          context: delegationContext,
           requestedByMember: member.id,
         });
+
+        // User-facing preview: the original ask wins when present (it's in
+        // the user's own words). When only a plan is in play (proactive plan
+        // → hire), fall back to a short reference to the plan task.
+        const userPreview = originalUserRequest
+          ? originalUserRequest.length > 120
+            ? `${originalUserRequest.slice(0, 120)}…`
+            : originalUserRequest
+          : `the accepted plan (${planTaskId})`;
 
         if (!delegated.ok) {
           const text =
             `✅ **${data.name}** is on staff.\n\n` +
-            `I tried to auto-delegate your request (_${originalUserRequest.slice(0, 120)}${originalUserRequest.length > 120 ? "…" : ""}_) but hit: ${delegated.error}\n\n` +
+            `I tried to auto-delegate your request (_${userPreview}_) but hit: ${delegated.error}\n\n` +
             `Just tell me what you want them to do and I'll retry.`;
           await multiRelay.sendMessage(task.agentId, member.telegramUserId, text);
           await threadHireAnnouncement(db, task.agentId, member.id, text, {
@@ -531,7 +573,7 @@ async function main() {
 
         const text =
           `✅ **${data.name}** is on staff — putting them on it now.\n\n` +
-          `_${originalUserRequest}_\n\n` +
+          `_${userPreview}_\n\n` +
           `I'll ping you when they're done. Say "kill ${data.name}'s task" to cancel.`;
         await multiRelay.sendMessage(task.agentId, member.telegramUserId, text);
         await threadHireAnnouncement(db, task.agentId, member.id, text, {

--- a/server/src/services/delegation-service.ts
+++ b/server/src/services/delegation-service.ts
@@ -111,6 +111,34 @@ export interface HireProposalError {
   error: string;
 }
 
+export interface AcceptPlanInput {
+  /** Agent calling accept_plan (the CoS, in practice). Used for household
+   * scoping; not currently used to gate ownership beyond the household. */
+  acceptingAgentId: string;
+  householdId: string;
+  /** The Planner task whose plan is being acted on. */
+  taskId: string;
+  decision: "accept" | "revise" | "replan";
+  /** Required when decision is `revise` or `replan`. */
+  notes?: string;
+}
+
+export type AcceptPlanResult =
+  | { ok: true; decision: "accept"; taskId: string }
+  | { ok: true; decision: "revise"; taskId: string; childTaskId: string }
+  | { ok: true; decision: "replan"; taskId: string };
+
+export type AcceptPlanError = {
+  ok: false;
+  error: string;
+  code:
+    | "E_TASK_NOT_FOUND"
+    | "E_WRONG_HOUSEHOLD"
+    | "E_NOT_A_PLAN"
+    | "E_PLAN_NOT_PENDING"
+    | "E_NOTES_REQUIRED";
+};
+
 export interface CancelTaskInput {
   householdId: string;
   runId?: string;
@@ -755,6 +783,217 @@ export class DelegationService {
     });
 
     return { ok: true };
+  }
+
+  /**
+   * Planner v2 — accept, revise, or replan a Planner's output. The
+   * architectural gate that gates Developer hires: only an `accepted`
+   * plan_task_id is valid for propose_hire on a Developer specialty.
+   *
+   * Validation runs in order: task existence, household scope, planning
+   * specialty, plan_status=pending_approval, notes required for revise/replan.
+   *
+   * Behavior:
+   *   accept:  plan_status -> 'accepted'. Logs plan_accepted.
+   *   revise:  plan_status -> 'revise'. Inserts a child Planner task with
+   *            parent_plan_task_id linking back, dispatches it. Logs
+   *            plan_revised on parent and created on child.
+   *   replan:  plan_status -> 'replan'. Logs plan_replan with notes; no
+   *            child task — CoS must manually re-delegate.
+   *
+   * The status flip + event log + child task insert run in a sync
+   * better-sqlite3 transaction so partial state is impossible. Dispatch
+   * fires after the transaction commits.
+   */
+  async handleAcceptPlan(
+    input: AcceptPlanInput,
+  ): Promise<AcceptPlanResult | AcceptPlanError> {
+    // -- Validation --------------------------------------------------
+    const [task] = await this.db
+      .select()
+      .from(tasks)
+      .where(eq(tasks.id, input.taskId))
+      .limit(1);
+    if (!task) {
+      return { ok: false, error: `task ${input.taskId} not found`, code: "E_TASK_NOT_FOUND" };
+    }
+    if (task.householdId !== input.householdId) {
+      return { ok: false, error: `task ${input.taskId} not found`, code: "E_WRONG_HOUSEHOLD" };
+    }
+
+    const plannerAgent = await this.loadAgent(task.agentId);
+    if (!plannerAgent || plannerAgent.specialty !== "planning") {
+      return {
+        ok: false,
+        error: `task ${input.taskId} is not a Planner task`,
+        code: "E_NOT_A_PLAN",
+      };
+    }
+
+    if (task.planStatus !== "pending_approval") {
+      return {
+        ok: false,
+        error: `plan is not pending approval (current plan_status: ${task.planStatus ?? "null"})`,
+        code: "E_PLAN_NOT_PENDING",
+      };
+    }
+
+    const notes = input.notes?.trim();
+    if ((input.decision === "revise" || input.decision === "replan") && !notes) {
+      return {
+        ok: false,
+        error: `decision '${input.decision}' requires non-empty notes`,
+        code: "E_NOTES_REQUIRED",
+      };
+    }
+
+    // -- Transactional state mutation -------------------------------
+    // better-sqlite3 transactions are sync; use .run()/.get()/.all().
+    const now = new Date();
+    let childTaskId: string | undefined;
+
+    if (input.decision === "accept") {
+      this.db.transaction((tx) => {
+        tx.update(tasks)
+          .set({ planStatus: "accepted", updatedAt: now })
+          .where(eq(tasks.id, input.taskId))
+          .run();
+        tx.insert(taskEvents)
+          .values({
+            taskId: input.taskId,
+            agentId: input.acceptingAgentId,
+            eventType: "plan_accepted",
+            message: `Plan accepted by ${input.acceptingAgentId}`,
+            payload: { decision: "accept", acceptingAgentId: input.acceptingAgentId },
+            clauseIds: null,
+          })
+          .run();
+      });
+      this.broadcast({
+        type: "plan.accepted",
+        data: { taskId: input.taskId, householdId: input.householdId },
+      });
+      return { ok: true, decision: "accept", taskId: input.taskId };
+    }
+
+    if (input.decision === "replan") {
+      this.db.transaction((tx) => {
+        tx.update(tasks)
+          .set({ planStatus: "replan", updatedAt: now })
+          .where(eq(tasks.id, input.taskId))
+          .run();
+        tx.insert(taskEvents)
+          .values({
+            taskId: input.taskId,
+            agentId: input.acceptingAgentId,
+            eventType: "plan_replan",
+            message: `Plan flagged replan: ${notes}`,
+            payload: { decision: "replan", notes, acceptingAgentId: input.acceptingAgentId },
+            clauseIds: null,
+          })
+          .run();
+      });
+      this.broadcast({
+        type: "plan.replan",
+        data: { taskId: input.taskId, householdId: input.householdId },
+      });
+      return { ok: true, decision: "replan", taskId: input.taskId };
+    }
+
+    // -- revise: parent flip + child insert atomically --------------
+    const childTitle = `Revise plan: ${task.title}`.slice(0, 240);
+    const childDescription = [
+      `Revising plan from task ${task.id}.`,
+      ``,
+      `Chief of Staff's revision notes:`,
+      notes ?? "",
+      ``,
+      `The parent task's brief was:`,
+      task.title,
+      task.description ? `\n${task.description}` : "",
+    ].join("\n");
+
+    this.db.transaction((tx) => {
+      tx.update(tasks)
+        .set({ planStatus: "revise", updatedAt: now })
+        .where(eq(tasks.id, input.taskId))
+        .run();
+
+      const inserted = tx
+        .insert(tasks)
+        .values({
+          householdId: input.householdId,
+          agentId: plannerAgent.id,
+          parentTaskId: null,
+          requestedBy: task.requestedBy,
+          assignedToMembers: null,
+          title: childTitle,
+          description: childDescription,
+          requiresApproval: false,
+          delegationDepth: 1,
+          status: "pending",
+          notifyAgentId: input.acceptingAgentId,
+          parentPlanTaskId: input.taskId,
+          updatedAt: now,
+        })
+        .returning({ id: tasks.id })
+        .all();
+      const childId = inserted[0].id;
+      childTaskId = childId;
+
+      tx.insert(taskEvents)
+        .values({
+          taskId: input.taskId,
+          agentId: input.acceptingAgentId,
+          eventType: "plan_revised",
+          message: `Plan flagged for revision: ${notes}`,
+          payload: { decision: "revise", notes, childTaskId: childId, acceptingAgentId: input.acceptingAgentId },
+          clauseIds: null,
+        })
+        .run();
+
+      tx.insert(taskEvents)
+        .values({
+          taskId: childId,
+          agentId: input.acceptingAgentId,
+          eventType: "created",
+          message: `Revision plan created from ${input.taskId}`,
+          payload: { parentPlanTaskId: input.taskId, fromRevision: true, notes },
+          clauseIds: null,
+        })
+        .run();
+    });
+
+    if (!childTaskId) {
+      // The transaction throws on failure rather than producing this state, so
+      // hitting this branch means a defensive type-narrowing bailout. Surface
+      // it as an error rather than dispatching nothing.
+      return {
+        ok: false,
+        error: "internal: revise transaction did not return a child task id",
+        code: "E_TASK_NOT_FOUND",
+      };
+    }
+
+    this.broadcast({
+      type: "plan.revised",
+      data: { taskId: input.taskId, childTaskId, householdId: input.householdId },
+    });
+    this.broadcast({
+      type: "task.created",
+      data: { taskId: childTaskId, householdId: input.householdId, agentId: plannerAgent.id, title: childTitle },
+    });
+
+    // Dispatch the revision task. Fire-and-forget — same pattern as
+    // handleDelegateTaskCall. Errors are logged; the task row stays pending
+    // and recoverStuckTasks will catch it on next boot if dispatch never ran.
+    this.dispatcher
+      .handleTaskAssignment(childTaskId)
+      .catch((err) =>
+        console.error(`[delegation] dispatch for revision ${childTaskId} failed:`, err),
+      );
+
+    return { ok: true, decision: "revise", taskId: input.taskId, childTaskId };
   }
 
   /**

--- a/server/src/services/delegation-service.ts
+++ b/server/src/services/delegation-service.ts
@@ -99,6 +99,11 @@ export interface HireProposalInput {
   /** Optional. User's original request, used to auto-delegate on approval so
    *  the user doesn't have to re-prompt. Absent for proactive hires. */
   originalUserRequest?: string;
+  /** Required for Developer specialties (tools/project/core). References a
+   *  Planner task whose plan_status is 'accepted'. The plan body becomes the
+   *  auto-delegation brief on hire.approved. Ignored for non-Developer
+   *  specialties even if supplied. */
+  planTaskId?: string;
 }
 
 export interface HireProposalResult {
@@ -109,6 +114,11 @@ export interface HireProposalResult {
 export interface HireProposalError {
   ok: false;
   error: string;
+  code?:
+    | "E_PLAN_REQUIRED"
+    | "E_PLAN_NOT_FOUND"
+    | "E_NOT_A_PLAN"
+    | "E_PLAN_NOT_ACCEPTED";
 }
 
 export interface AcceptPlanInput {
@@ -410,6 +420,50 @@ export class DelegationService {
       return { ok: false, error: "oversight not wired (server boot order)" };
     }
 
+    // Planner v2: Developer hires require an accepted plan_task_id. Non-
+    // Developer specialties ignore plan_task_id even if supplied — the
+    // architectural gate only applies to specialties that actually ship code.
+    const isDevHire = isDeveloperSpecialty(input.specialty);
+    let resolvedPlanTaskId: string | undefined;
+    if (isDevHire) {
+      if (!input.planTaskId) {
+        return {
+          ok: false,
+          error: `Developer hires (${input.specialty}) require plan_task_id from an accepted Planner task. Run accept_plan first.`,
+          code: "E_PLAN_REQUIRED",
+        };
+      }
+      const [planTask] = await this.db
+        .select()
+        .from(tasks)
+        .where(eq(tasks.id, input.planTaskId))
+        .limit(1);
+      if (!planTask || planTask.householdId !== input.householdId) {
+        return {
+          ok: false,
+          error: `plan task ${input.planTaskId} not found`,
+          code: "E_PLAN_NOT_FOUND",
+        };
+      }
+      const plannerAgent = await this.loadAgent(planTask.agentId);
+      if (!plannerAgent || plannerAgent.specialty !== "planning") {
+        return {
+          ok: false,
+          error: `task ${input.planTaskId} is not a Planner task`,
+          code: "E_NOT_A_PLAN",
+        };
+      }
+      if (planTask.planStatus !== "accepted") {
+        return {
+          ok: false,
+          error: `plan ${input.planTaskId} is not accepted (current plan_status: ${planTask.planStatus ?? "null"})`,
+          code: "E_PLAN_NOT_ACCEPTED",
+        };
+      }
+      resolvedPlanTaskId = input.planTaskId;
+    }
+    // For non-Developer hires, plan_task_id is silently ignored.
+
     const review = await this.oversight.reviewHireProposal({
       householdId: input.householdId,
       proposedByAgentId: input.proposedByAgentId,
@@ -436,6 +490,7 @@ export class DelegationService {
         model: input.model,
         trustLevel: input.trustLevel,
         originalUserRequest: input.originalUserRequest,
+        planTaskId: resolvedPlanTaskId,
       }),
       requiresApproval: true,
       delegationDepth: 0,

--- a/server/src/services/delegation/__tests__/plan-acceptance.test.ts
+++ b/server/src/services/delegation/__tests__/plan-acceptance.test.ts
@@ -1,0 +1,469 @@
+/**
+ * Critical-path tests for Planner v2 infrastructure.
+ *
+ * Four groups, each verifying one load-bearing structural guarantee:
+ *   A. Frontmatter parser — valid + malformed plans
+ *   B. accept_plan       — state transitions + household scoping
+ *   C. propose_hire      — plan validation gate
+ *   D. revision linkage  — parent_plan_task_id chain
+ *
+ * Stubs follow the existing delegation-service.test.ts pattern: real DB
+ * (in-memory), stub Adapter / Dispatcher / TaskEngine / Oversight. The goal
+ * is DB-invariant verification, not subprocess pipelines.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { createDb, type Db } from "@carsonos/db";
+import {
+  households,
+  staffAgents,
+  familyMembers,
+  tasks,
+  taskEvents,
+  delegationEdges,
+} from "@carsonos/db";
+import { DelegationService } from "../../delegation-service.js";
+import { TaskEngine } from "../../task-engine.js";
+import type { Dispatcher } from "../../dispatcher.js";
+import type { CarsonOversight } from "../../carson-oversight.js";
+import { parsePlanResult } from "../plan-parser.js";
+
+// ── Shared fixtures ─────────────────────────────────────────────
+
+function stubAdapter() {
+  return {
+    name: "stub",
+    execute: vi.fn().mockResolvedValue({ content: "stub" }),
+    healthCheck: vi.fn().mockResolvedValue(true),
+  };
+}
+
+function stubDispatcher() {
+  return {
+    handleTaskAssignment: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Dispatcher;
+}
+
+function stubOversight() {
+  return {
+    reviewHireProposal: vi.fn().mockResolvedValue({
+      approved: false,
+      reason: "Hire proposals always require principal approval",
+    }),
+  } as unknown as CarsonOversight;
+}
+
+async function seedHousehold(db: Db) {
+  const [household] = await db.insert(households).values({ name: "test" }).returning();
+  const [principal] = await db
+    .insert(familyMembers)
+    .values({ householdId: household.id, name: "Josh", role: "parent", age: 40, telegramUserId: "1" })
+    .returning();
+  const [cos] = await db
+    .insert(staffAgents)
+    .values({ householdId: household.id, name: "Carson", staffRole: "head_butler", isHeadButler: true })
+    .returning();
+  const [planner] = await db
+    .insert(staffAgents)
+    .values({
+      householdId: household.id,
+      name: "Pat",
+      staffRole: "custom",
+      specialty: "planning",
+      visibility: "internal",
+      autonomyLevel: "autonomous",
+    })
+    .returning();
+  return { householdId: household.id, principalId: principal.id, cosId: cos.id, plannerId: planner.id };
+}
+
+function makeService(db: Db) {
+  const adapter = stubAdapter();
+  const dispatcher = stubDispatcher();
+  const oversight = stubOversight();
+  const broadcasts: Array<{ type: string; data?: unknown }> = [];
+  const capture = (e: { type: string; data?: unknown }) => {
+    broadcasts.push(e);
+  };
+  const taskEngine = new TaskEngine({
+    db,
+    adapter: adapter as never,
+    constitutionEngine: undefined as never,
+    broadcast: capture,
+  });
+  const svc = new DelegationService(
+    { db, adapter: adapter as never, broadcast: capture },
+    dispatcher,
+    taskEngine,
+  );
+  svc.setOversight(oversight);
+  return { svc, dispatcher, oversight, broadcasts };
+}
+
+type PlanStatus = "pending_approval" | "accepted" | "revise" | "replan";
+
+async function createPendingPlanTask(
+  db: Db,
+  ids: { householdId: string; principalId: string; plannerId: string },
+  overrides: { status?: string; planStatus?: PlanStatus | null; description?: string } = {},
+) {
+  const [task] = await db
+    .insert(tasks)
+    .values({
+      householdId: ids.householdId,
+      agentId: ids.plannerId,
+      requestedBy: ids.principalId,
+      title: "design the auth refactor",
+      description: overrides.description ?? "the original brief",
+      status: overrides.status ?? "completed",
+      requiresApproval: false,
+      delegationDepth: 1,
+      planStatus:
+        overrides.planStatus === undefined ? "pending_approval" : overrides.planStatus,
+    })
+    .returning();
+  return task;
+}
+
+// ── Group A: Frontmatter parser ─────────────────────────────────
+
+describe("parsePlanResult", () => {
+  it("parses a valid complete plan with frontmatter", () => {
+    const body = `---
+plan_state: complete
+target_developer: core
+foundational_invariant: "depth-2 holds"
+state_location: "tasks.delegation_depth"
+failure_modes_considered:
+  - "infinite recursion"
+prior_plans_consulted: []
+decisions_referenced: []
+estimated_complexity: small
+out_of_scope: []
+open_questions: []
+---
+
+# Interpretation
+
+We need to enforce depth-2 properly.
+`;
+    const result = parsePlanResult(body);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.frontmatter.plan_state).toBe("complete");
+    if (result.frontmatter.plan_state === "complete") {
+      expect(result.frontmatter.target_developer).toBe("core");
+      expect(result.frontmatter.estimated_complexity).toBe("small");
+    }
+    expect(result.body).toContain("Interpretation");
+  });
+
+  it("parses a valid programming_incomplete plan", () => {
+    const body = `---
+plan_state: programming_incomplete
+programming_questions:
+  - "should we use postgres or sqlite?"
+prior_plans_consulted: []
+decisions_referenced: []
+---
+
+The brief leaves the storage layer undecided.
+`;
+    const result = parsePlanResult(body);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.frontmatter.plan_state).toBe("programming_incomplete");
+    if (result.frontmatter.plan_state === "programming_incomplete") {
+      expect(result.frontmatter.programming_questions).toHaveLength(1);
+    }
+  });
+
+  it("rejects a complete plan missing foundational_invariant", () => {
+    const body = `---
+plan_state: complete
+target_developer: core
+state_location: "tasks.delegation_depth"
+failure_modes_considered: []
+prior_plans_consulted: []
+decisions_referenced: []
+estimated_complexity: small
+out_of_scope: []
+open_questions: []
+---
+
+body
+`;
+    const result = parsePlanResult(body);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("foundational_invariant");
+  });
+
+  it("rejects a plan with invalid target_developer value", () => {
+    const body = `---
+plan_state: complete
+target_developer: kernel
+foundational_invariant: "x"
+state_location: "y"
+failure_modes_considered: []
+prior_plans_consulted: []
+decisions_referenced: []
+estimated_complexity: small
+out_of_scope: []
+open_questions: []
+---
+
+body
+`;
+    const result = parsePlanResult(body);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("target_developer");
+  });
+});
+
+// ── Group B: accept_plan state transitions ──────────────────────
+
+describe("acceptPlan", () => {
+  let db: Db;
+  let ids: Awaited<ReturnType<typeof seedHousehold>>;
+
+  beforeEach(async () => {
+    db = createDb(":memory:");
+    ids = await seedHousehold(db);
+  });
+
+  it("transitions pending_approval to accepted on decision=accept", async () => {
+    const planTask = await createPendingPlanTask(db, ids);
+    const { svc } = makeService(db);
+
+    const result = await svc.handleAcceptPlan({
+      acceptingAgentId: ids.cosId,
+      householdId: ids.householdId,
+      taskId: planTask.id,
+      decision: "accept",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.decision).toBe("accept");
+
+    const [updated] = await db.select().from(tasks).where(eq(tasks.id, planTask.id));
+    expect(updated.planStatus).toBe("accepted");
+
+    const events = await db.select().from(taskEvents).where(eq(taskEvents.taskId, planTask.id));
+    expect(events.some((e) => e.eventType === "plan_accepted")).toBe(true);
+  });
+
+  it("creates child task with parent_plan_task_id on decision=revise", async () => {
+    const planTask = await createPendingPlanTask(db, ids);
+    const { svc, dispatcher } = makeService(db);
+
+    const result = await svc.handleAcceptPlan({
+      acceptingAgentId: ids.cosId,
+      householdId: ids.householdId,
+      taskId: planTask.id,
+      decision: "revise",
+      notes: "tighten the depth-2 explanation",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.decision).toBe("revise");
+    if (result.decision !== "revise") return;
+    expect(result.childTaskId).toBeDefined();
+
+    const [child] = await db.select().from(tasks).where(eq(tasks.id, result.childTaskId));
+    expect(child.parentPlanTaskId).toBe(planTask.id);
+    expect(child.agentId).toBe(ids.plannerId);
+    expect(child.notifyAgentId).toBe(ids.cosId);
+
+    // Dispatch fired for the revision task (fire-and-forget, give it a tick)
+    await new Promise((r) => setTimeout(r, 5));
+    expect(dispatcher.handleTaskAssignment).toHaveBeenCalledWith(result.childTaskId);
+  });
+
+  it("rejects acceptance of a task in a different household", async () => {
+    const planTask = await createPendingPlanTask(db, ids);
+    const [otherHousehold] = await db.insert(households).values({ name: "other" }).returning();
+
+    const { svc } = makeService(db);
+
+    const result = await svc.handleAcceptPlan({
+      acceptingAgentId: ids.cosId,
+      householdId: otherHousehold.id,
+      taskId: planTask.id,
+      decision: "accept",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("E_WRONG_HOUSEHOLD");
+  });
+
+  it("rejects acceptance of a non-Planner task", async () => {
+    // Seed a non-Planner agent + a task on it carrying a plan_status (which
+    // shouldn't happen in normal flow but we want to verify the gate is on
+    // the agent's specialty, not just plan_status).
+    const [bob] = await db
+      .insert(staffAgents)
+      .values({
+        householdId: ids.householdId,
+        name: "Bob",
+        staffRole: "custom",
+        specialty: "tools",
+        visibility: "internal",
+      })
+      .returning();
+    const [bobTask] = await db
+      .insert(tasks)
+      .values({
+        householdId: ids.householdId,
+        agentId: bob.id,
+        requestedBy: ids.principalId,
+        title: "build something",
+        status: "completed",
+        requiresApproval: false,
+        delegationDepth: 1,
+        planStatus: "pending_approval",
+      })
+      .returning();
+
+    const { svc } = makeService(db);
+    const result = await svc.handleAcceptPlan({
+      acceptingAgentId: ids.cosId,
+      householdId: ids.householdId,
+      taskId: bobTask.id,
+      decision: "accept",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("E_NOT_A_PLAN");
+  });
+});
+
+// ── Group C: propose_hire plan validation ───────────────────────
+
+describe("proposeHire plan validation", () => {
+  let db: Db;
+  let ids: Awaited<ReturnType<typeof seedHousehold>>;
+
+  beforeEach(async () => {
+    db = createDb(":memory:");
+    ids = await seedHousehold(db);
+  });
+
+  it("rejects a Developer hire without plan_task_id", async () => {
+    const { svc } = makeService(db);
+
+    const result = await svc.handleHireProposal({
+      householdId: ids.householdId,
+      proposedByAgentId: ids.cosId,
+      proposedByMemberId: ids.principalId,
+      role: "Developer",
+      specialty: "tools",
+      reason: "build the todoist tool",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("E_PLAN_REQUIRED");
+  });
+
+  it("rejects a Developer hire with a plan_task_id that's not accepted", async () => {
+    const planTask = await createPendingPlanTask(db, ids); // plan_status = pending_approval
+    const { svc } = makeService(db);
+
+    const result = await svc.handleHireProposal({
+      householdId: ids.householdId,
+      proposedByAgentId: ids.cosId,
+      proposedByMemberId: ids.principalId,
+      role: "Developer",
+      specialty: "tools",
+      reason: "ship the todoist tool",
+      planTaskId: planTask.id,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("E_PLAN_NOT_ACCEPTED");
+  });
+
+  it("accepts a non-Developer hire (planning) without plan_task_id", async () => {
+    const { svc } = makeService(db);
+
+    const result = await svc.handleHireProposal({
+      householdId: ids.householdId,
+      proposedByAgentId: ids.cosId,
+      proposedByMemberId: ids.principalId,
+      role: "Planner",
+      specialty: "planning",
+      reason: "we need an architect",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.approvalTaskId).toBeDefined();
+  });
+});
+
+// ── Group D: Revision linkage ───────────────────────────────────
+
+describe("plan revision", () => {
+  let db: Db;
+  let ids: Awaited<ReturnType<typeof seedHousehold>>;
+
+  beforeEach(async () => {
+    db = createDb(":memory:");
+    ids = await seedHousehold(db);
+    // Edge needed if dispatch path inspects edges; the revision dispatch in
+    // accept_plan goes directly through dispatcher.handleTaskAssignment, but
+    // wiring the edge keeps the seed faithful to a real CoS->Planner setup.
+    await db.insert(delegationEdges).values({ fromAgentId: ids.cosId, toAgentId: ids.plannerId });
+  });
+
+  it("creates child task with correct parent_plan_task_id on revise", async () => {
+    const planTask = await createPendingPlanTask(db, ids, { description: "make it tidy" });
+    const { svc } = makeService(db);
+
+    const result = await svc.handleAcceptPlan({
+      acceptingAgentId: ids.cosId,
+      householdId: ids.householdId,
+      taskId: planTask.id,
+      decision: "revise",
+      notes: "rework section 3",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.decision !== "revise") return;
+
+    const [child] = await db.select().from(tasks).where(eq(tasks.id, result.childTaskId));
+    expect(child.parentPlanTaskId).toBe(planTask.id);
+    expect(child.description).toContain("rework section 3");
+    expect(child.description).toContain("make it tidy");
+
+    const childEvents = await db.select().from(taskEvents).where(eq(taskEvents.taskId, child.id));
+    expect(childEvents.some((e) => e.eventType === "created")).toBe(true);
+  });
+
+  it("updates parent plan_status to 'revise' on revision", async () => {
+    const planTask = await createPendingPlanTask(db, ids);
+    const { svc } = makeService(db);
+
+    await svc.handleAcceptPlan({
+      acceptingAgentId: ids.cosId,
+      householdId: ids.householdId,
+      taskId: planTask.id,
+      decision: "revise",
+      notes: "narrow the scope",
+    });
+
+    const [updated] = await db.select().from(tasks).where(eq(tasks.id, planTask.id));
+    expect(updated.planStatus).toBe("revise");
+
+    const events = await db.select().from(taskEvents).where(eq(taskEvents.taskId, planTask.id));
+    expect(events.some((e) => e.eventType === "plan_revised")).toBe(true);
+  });
+});

--- a/server/src/services/delegation/__tests__/plan-acceptance.test.ts
+++ b/server/src/services/delegation/__tests__/plan-acceptance.test.ts
@@ -295,6 +295,51 @@ The actual plan body.
     expect(result.body).not.toContain("```");
   });
 
+  it("tolerates narration plus markdown horizontal rule before fenced frontmatter", () => {
+    // Pattern 3 from the parser's tolerance NOTE — observed in three smoke-
+    // test runs (2026-04-26): the Planner emits narration, then a standalone
+    // '---' (markdown horizontal rule), then a fenced yaml block whose own
+    // '---' delimiters carry the real frontmatter.
+    const body = [
+      "I'll read the codebase first.",
+      "Now let me check the memory tools.",
+      "I have a complete picture. Producing the plan now.",
+      "",
+      "---",
+      "",
+      "```yaml",
+      "---",
+      "plan_state: complete",
+      "target_developer: project",
+      'foundational_invariant: "x"',
+      'state_location: "y"',
+      "failure_modes_considered: []",
+      "prior_plans_consulted: []",
+      "decisions_referenced: []",
+      "estimated_complexity: large",
+      "out_of_scope: []",
+      "open_questions: []",
+      "---",
+      "```",
+      "",
+      "## Interpretation",
+      "",
+      "The plan body content here.",
+    ].join("\n");
+
+    const result = parsePlanResult(body);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.frontmatter.plan_state === "complete") {
+      expect(result.frontmatter.target_developer).toBe("project");
+      expect(result.frontmatter.estimated_complexity).toBe("large");
+    }
+    expect(result.body).toContain("## Interpretation");
+    expect(result.body).toContain("The plan body content here");
+    expect(result.body).not.toContain("```");
+    expect(result.body).not.toContain("I'll read the codebase");
+  });
+
   it("still rejects input with no frontmatter delimiter at all", () => {
     const body = `# Just markdown
 

--- a/server/src/services/delegation/__tests__/plan-acceptance.test.ts
+++ b/server/src/services/delegation/__tests__/plan-acceptance.test.ts
@@ -221,6 +221,90 @@ body
     if (result.ok) return;
     expect(result.error).toContain("target_developer");
   });
+
+  it("tolerates leading narration before frontmatter", () => {
+    const body = `Let me read the codebase first.
+Reading packages/db/src/schema.ts...
+Reading the dispatcher hook now.
+Let me check the existing tests too.
+Now writing the plan.
+
+---
+plan_state: complete
+target_developer: core
+foundational_invariant: "x"
+state_location: "y"
+failure_modes_considered: []
+prior_plans_consulted: []
+decisions_referenced: []
+estimated_complexity: small
+out_of_scope: []
+open_questions: []
+---
+
+# Interpretation
+
+The actual plan body.
+`;
+    const result = parsePlanResult(body);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.frontmatter.plan_state === "complete") {
+      expect(result.frontmatter.target_developer).toBe("core");
+    }
+    expect(result.body).toContain("# Interpretation");
+    expect(result.body).toContain("The actual plan body");
+    expect(result.body).not.toContain("Let me read the codebase");
+  });
+
+  it("tolerates a yaml code fence wrapping the frontmatter", () => {
+    const body = [
+      "Some narration first.",
+      "",
+      "```yaml",
+      "---",
+      "plan_state: complete",
+      "target_developer: tools",
+      'foundational_invariant: "x"',
+      'state_location: "y"',
+      "failure_modes_considered: []",
+      "prior_plans_consulted: []",
+      "decisions_referenced: []",
+      "estimated_complexity: medium",
+      "out_of_scope: []",
+      "open_questions: []",
+      "---",
+      "",
+      "# Interpretation",
+      "",
+      "fenced plan body content",
+      "```",
+      "",
+      "trailing notes outside the fence",
+    ].join("\n");
+
+    const result = parsePlanResult(body);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    if (result.frontmatter.plan_state === "complete") {
+      expect(result.frontmatter.target_developer).toBe("tools");
+    }
+    expect(result.body).toContain("# Interpretation");
+    expect(result.body).toContain("fenced plan body content");
+    expect(result.body).toContain("trailing notes outside the fence");
+    expect(result.body).not.toContain("```");
+  });
+
+  it("still rejects input with no frontmatter delimiter at all", () => {
+    const body = `# Just markdown
+
+No frontmatter here, just prose. Nothing for the parser to anchor on.
+`;
+    const result = parsePlanResult(body);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("missing required YAML frontmatter");
+  });
 });
 
 // ── Group B: accept_plan state transitions ──────────────────────

--- a/server/src/services/delegation/delegation-tools.ts
+++ b/server/src/services/delegation/delegation-tools.ts
@@ -173,6 +173,27 @@ export const DELEGATION_TOOLS: ToolDefinition[] = [
     },
   },
   {
+    name: "accept_plan",
+    description:
+      "Accept, revise, or replan a Planner's output. Required before hiring a Developer — Developer hires must reference an accepted plan via plan_task_id. The Planner is the architect; you are the client. Use accept when the plan is correct as-is. Use revise when the plan needs adjustment but the interpretation is right (a child Planner task is auto-delegated with your notes). Use replan when the interpretation is wrong and the work must start over (no child task; you re-delegate manually).",
+    input_schema: {
+      type: "object",
+      properties: {
+        task_id: { type: "string", description: "The Planner task whose plan is being acted on. Returned by delegate_task / surfaced when the Planner finished." },
+        decision: {
+          type: "string",
+          enum: ["accept", "revise", "replan"],
+          description: "accept = plan is good, hire a Developer next; revise = plan needs adjustment, auto-delegates a revision; replan = wrong interpretation, marks the plan replan and waits for you to re-delegate.",
+        },
+        notes: {
+          type: "string",
+          description: "Required when decision is revise or replan; explains what should change. Ignored when decision is accept.",
+        },
+      },
+      required: ["task_id", "decision"],
+    },
+  },
+  {
     name: "register_project",
     description:
       "Register a project so Developers can target it via projectId. Required before delegating project/core specialty work. Explicit registration only — folder-scan discovery is a v0.5 feature.",
@@ -211,6 +232,8 @@ export async function handleDelegationTool(
       return handleListActiveTasks(context);
     case "register_project":
       return handleRegisterProject(input, context);
+    case "accept_plan":
+      return handleAcceptPlan(input, context);
     case "read_task_result":
       return handleReadTaskResult(input, context);
     case "grant_delegation":
@@ -465,6 +488,45 @@ async function handleRegisterProject(
     }
     return toolError(`Failed to register project: ${msg}`);
   }
+}
+
+async function handleAcceptPlan(
+  input: Record<string, unknown>,
+  ctx: DelegationToolContext,
+): Promise<ToolResult> {
+  const taskId = stringArg(input.task_id);
+  const decision = stringArg(input.decision);
+  const notes = stringArg(input.notes) ?? undefined;
+  if (!taskId) return toolError("accept_plan requires `task_id`");
+  if (!decision || !["accept", "revise", "replan"].includes(decision)) {
+    return toolError("accept_plan requires `decision` of 'accept' | 'revise' | 'replan'");
+  }
+
+  const result = await ctx.delegationService.handleAcceptPlan({
+    acceptingAgentId: ctx.agentId,
+    householdId: ctx.householdId,
+    taskId,
+    decision: decision as "accept" | "revise" | "replan",
+    notes,
+  });
+
+  if (!result.ok) return toolError(result.error);
+  if (result.decision === "accept") {
+    return toolOk(
+      `Plan accepted. You can now propose_hire a Developer with plan_task_id="${result.taskId}".`,
+      { decision: "accept", taskId: result.taskId },
+    );
+  }
+  if (result.decision === "revise") {
+    return toolOk(
+      `Plan flagged for revision. A new Planner task is in flight; you'll be notified when the revised plan is ready.\nrevisionTaskId: ${result.childTaskId}`,
+      { decision: "revise", taskId: result.taskId, childTaskId: result.childTaskId },
+    );
+  }
+  return toolOk(
+    `Plan flagged replan. Re-delegate to the Planner with a clearer brief when ready.`,
+    { decision: "replan", taskId: result.taskId },
+  );
 }
 
 async function handleReadTaskResult(

--- a/server/src/services/delegation/delegation-tools.ts
+++ b/server/src/services/delegation/delegation-tools.ts
@@ -112,6 +112,10 @@ export const DELEGATION_TOOLS: ToolDefinition[] = [
           type: "string",
           description: "The user's original ask in their own words — what they want the new specialist to DO. If set, the system auto-delegates this to the specialist immediately on approval; the user doesn't have to re-prompt. Example: if the user said 'build me a Todoist tool', pass 'build me a Todoist tool' (or a clean-up of it). Omit only for proactive hires not tied to a specific task.",
         },
+        plan_task_id: {
+          type: "string",
+          description: "Required for Developer specialties (tools, project, core) — must reference a Planner task whose plan_status is 'accepted'. The plan body becomes the auto-delegation brief on approval. Non-Developer specialties (planning, research, etc.) ignore this field; supply it only when hiring a Developer to execute an accepted plan.",
+        },
       },
       required: ["role", "specialty", "reason"],
     },
@@ -285,6 +289,7 @@ async function handleProposeHire(
   const model = stringArg(input.model) ?? undefined;
   const trustLevel = stringArg(input.trustLevel) ?? undefined;
   const originalUserRequest = stringArg(input.originalUserRequest) ?? undefined;
+  const planTaskId = stringArg(input.plan_task_id) ?? undefined;
 
   if (!role) return toolError("propose_hire requires `role` (e.g., 'Developer', 'Researcher', 'Music specialist')");
   if (!specialty) return toolError("propose_hire requires `specialty` (kebab-case; e.g., 'tools', 'research', 'music')");
@@ -308,6 +313,7 @@ async function handleProposeHire(
     model,
     trustLevel: trustLevel as "full" | "standard" | "restricted" | undefined,
     originalUserRequest,
+    planTaskId,
   });
 
   if (!result.ok) return toolError(result.error);

--- a/server/src/services/delegation/plan-parser.ts
+++ b/server/src/services/delegation/plan-parser.ts
@@ -54,26 +54,58 @@ export type ParsePlanResult =
  * Anything that doesn't match — missing fields, wrong types, no frontmatter
  * at all — returns ok:false with a human-readable error.
  *
- * Two narrow tolerances on input shape, both grounded in real failure modes:
- *   1. The SDK adapter concatenates tool-use narration ("Let me read the
- *      codebase…") in front of the structured plan output. We strip
- *      everything before the first '---' on its own line.
- *   2. The Planner sometimes mimics the template literally and wraps the
- *      frontmatter in a ```yaml code fence. If a fence opener immediately
- *      precedes the first '---', we strip it and also strip the matching
- *      closing fence line from the body after parsing.
- *
- * These tolerances widen "what counts as parseable input" — they do not
- * weaken schema validation. Missing required fields still fail.
+ * Three narrow tolerances on input shape — see the inline NOTE inside
+ * parsePlanResult for the enumerated shapes and the cap policy. These
+ * tolerances widen "what counts as parseable input" — they do not weaken
+ * schema validation. Missing required fields still fail.
  */
 export function parsePlanResult(taskBody: string): ParsePlanResult {
+  // ── Input tolerance preprocessing ──────────────────────────────────
+  // NOTE: this block tolerates THREE specific shapes of malformed Planner
+  // output observed during v0.4 smoke testing:
+  //   1. Leading narration before the frontmatter (tool-use deltas
+  //      concatenated by the SDK adapter).
+  //   2. A yaml code fence whose opener immediately precedes the '---'
+  //      delimiter.
+  //   3. Narration → '---' (markdown horizontal rule) → blank → '```yaml'
+  //      → '---' → keys, where the first '---' is an HR and the inner
+  //      '---' is the real frontmatter start.
+  //
+  // No additional shapes will be added here. If a fourth shape appears,
+  // the correct fix is the structured tool-call refactor — see TODO Gap 5
+  // in ~/.claude/projects/-Users-collinmadsen-carson-os/memory/todo_approval_flow_gaps.md.
+  // The parser tolerance code below is scheduled for removal, not
+  // extension. Adding a fourth tolerance reopens the slippery slope this
+  // policy was written to close.
   const lines = taskBody.split("\n");
-  const fmStart = lines.findIndex((l) => l === "---");
+  let fmStart = lines.findIndex((l) => l === "---");
   if (fmStart === -1) {
     return { ok: false, error: "plan is missing required YAML frontmatter" };
   }
-  const hadFenceOpener =
+
+  // Pattern 2: fence opener immediately precedes the first '---'.
+  let hadFenceOpener =
     fmStart > 0 && /^```ya?ml\s*$/i.test(lines[fmStart - 1]);
+
+  // Pattern 3: the first '---' is followed (past blanks) by a yaml fence
+  // opener and a second '---'. Treat the inner '---' as the real start;
+  // the outer one was a markdown horizontal rule.
+  if (!hadFenceOpener) {
+    const lookahead: { idx: number; line: string }[] = [];
+    for (let i = fmStart + 1; i < lines.length && lookahead.length < 2; i++) {
+      if (lines[i].trim() === "") continue;
+      lookahead.push({ idx: i, line: lines[i] });
+    }
+    if (
+      lookahead.length >= 2 &&
+      /^```ya?ml\s*$/i.test(lookahead[0].line) &&
+      lookahead[1].line === "---"
+    ) {
+      fmStart = lookahead[1].idx;
+      hadFenceOpener = true;
+    }
+  }
+
   const reconstructed = lines.slice(fmStart).join("\n");
 
   let parsed: { data: Record<string, unknown>; content: string };

--- a/server/src/services/delegation/plan-parser.ts
+++ b/server/src/services/delegation/plan-parser.ts
@@ -53,11 +53,32 @@ export type ParsePlanResult =
  * gray-matter pulls the YAML block; zod validates the discriminated union.
  * Anything that doesn't match — missing fields, wrong types, no frontmatter
  * at all — returns ok:false with a human-readable error.
+ *
+ * Two narrow tolerances on input shape, both grounded in real failure modes:
+ *   1. The SDK adapter concatenates tool-use narration ("Let me read the
+ *      codebase…") in front of the structured plan output. We strip
+ *      everything before the first '---' on its own line.
+ *   2. The Planner sometimes mimics the template literally and wraps the
+ *      frontmatter in a ```yaml code fence. If a fence opener immediately
+ *      precedes the first '---', we strip it and also strip the matching
+ *      closing fence line from the body after parsing.
+ *
+ * These tolerances widen "what counts as parseable input" — they do not
+ * weaken schema validation. Missing required fields still fail.
  */
 export function parsePlanResult(taskBody: string): ParsePlanResult {
+  const lines = taskBody.split("\n");
+  const fmStart = lines.findIndex((l) => l === "---");
+  if (fmStart === -1) {
+    return { ok: false, error: "plan is missing required YAML frontmatter" };
+  }
+  const hadFenceOpener =
+    fmStart > 0 && /^```ya?ml\s*$/i.test(lines[fmStart - 1]);
+  const reconstructed = lines.slice(fmStart).join("\n");
+
   let parsed: { data: Record<string, unknown>; content: string };
   try {
-    parsed = matter(taskBody);
+    parsed = matter(reconstructed);
   } catch (err) {
     return {
       ok: false,
@@ -77,5 +98,18 @@ export function parsePlanResult(taskBody: string): ParsePlanResult {
     return { ok: false, error: `frontmatter validation failed: ${issues}` };
   }
 
-  return { ok: true, frontmatter: validation.data, body: parsed.content };
+  let body = parsed.content;
+  if (hadFenceOpener) {
+    // Strip the corresponding closing triple-backtick line if present.
+    // Anything after the closer stays in the body (the LLM occasionally
+    // appends final notes outside the fence).
+    const bodyLines = body.split("\n");
+    const closerIdx = bodyLines.findIndex((l) => /^```\s*$/.test(l));
+    if (closerIdx !== -1) {
+      bodyLines.splice(closerIdx, 1);
+      body = bodyLines.join("\n");
+    }
+  }
+
+  return { ok: true, frontmatter: validation.data, body };
 }

--- a/server/src/services/delegation/plan-parser.ts
+++ b/server/src/services/delegation/plan-parser.ts
@@ -1,0 +1,81 @@
+/**
+ * Planner v2 — frontmatter parser for the architectural plan format.
+ *
+ * Planner agents produce markdown with a YAML frontmatter header. The body is
+ * read by the Chief of Staff; the frontmatter is the structural contract this
+ * module enforces. A malformed plan fails the task with E_PLAN_MALFORMED so
+ * the gate stays load-bearing — accept_plan only sees plans that already
+ * cleared schema validation.
+ *
+ * Two terminal states (discriminated on `plan_state`):
+ *   - "complete":               full plan, eligible for accept_plan
+ *   - "programming_incomplete": pre-design questions; not eligible for accept_plan
+ */
+
+import matter from "gray-matter";
+import { z } from "zod";
+
+const completeSchema = z.object({
+  plan_state: z.literal("complete"),
+  target_developer: z.enum(["core", "project", "tools"]),
+  foundational_invariant: z.string().min(1),
+  state_location: z.string().min(1),
+  failure_modes_considered: z.array(z.string()),
+  prior_plans_consulted: z.array(z.string()),
+  decisions_referenced: z.array(z.string()),
+  estimated_complexity: z.enum(["small", "medium", "large"]),
+  out_of_scope: z.array(z.string()),
+  open_questions: z.array(z.string()),
+  parent_plan_task_id: z.string().optional(),
+});
+
+const programmingIncompleteSchema = z.object({
+  plan_state: z.literal("programming_incomplete"),
+  programming_questions: z.array(z.string().min(1)).min(1),
+  prior_plans_consulted: z.array(z.string()),
+  decisions_referenced: z.array(z.string()),
+  parent_plan_task_id: z.string().optional(),
+});
+
+export const planFrontmatterSchema = z.discriminatedUnion("plan_state", [
+  completeSchema,
+  programmingIncompleteSchema,
+]);
+
+export type PlanFrontmatter = z.infer<typeof planFrontmatterSchema>;
+
+export type ParsePlanResult =
+  | { ok: true; frontmatter: PlanFrontmatter; body: string }
+  | { ok: false; error: string };
+
+/**
+ * Parse a Planner task's result body into structured frontmatter + body.
+ * gray-matter pulls the YAML block; zod validates the discriminated union.
+ * Anything that doesn't match — missing fields, wrong types, no frontmatter
+ * at all — returns ok:false with a human-readable error.
+ */
+export function parsePlanResult(taskBody: string): ParsePlanResult {
+  let parsed: { data: Record<string, unknown>; content: string };
+  try {
+    parsed = matter(taskBody);
+  } catch (err) {
+    return {
+      ok: false,
+      error: `frontmatter parse failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  if (!parsed.data || Object.keys(parsed.data).length === 0) {
+    return { ok: false, error: "plan is missing required YAML frontmatter" };
+  }
+
+  const validation = planFrontmatterSchema.safeParse(parsed.data);
+  if (!validation.success) {
+    const issues = validation.error.issues
+      .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+      .join("; ");
+    return { ok: false, error: `frontmatter validation failed: ${issues}` };
+  }
+
+  return { ok: true, frontmatter: validation.data, body: parsed.content };
+}

--- a/server/src/services/delegation/specialty-templates/index.ts
+++ b/server/src/services/delegation/specialty-templates/index.ts
@@ -31,15 +31,27 @@ export type DeveloperSpecialty = keyof typeof SPECIALTY_TEMPLATES;
 
 export const COS_DELEGATION_PREAMBLE = load("cos-delegation-preamble");
 
+/** Planner v2 — non-Developer specialty with a curated architectural template.
+ *  Kept separate from SPECIALTY_TEMPLATES so downstream code that branches on
+ *  Developer-vs-other (Dispatcher.executeDeveloperTask, hire defaults) keeps
+ *  its existing semantics. */
+export const PLANNER_TEMPLATE = load("planner");
+
 export function isDeveloperSpecialty(specialty: string): specialty is DeveloperSpecialty {
   return specialty === "tools" || specialty === "project" || specialty === "core";
 }
 
-/** Returns the operating-instructions body for a Developer-specialty hire, or
- *  null if the specialty isn't one of the curated Developer kinds. Non-Developer
- *  specialists fall through to composeGenericSpecialistInstructions(). */
+/** Returns the operating-instructions body for a curated specialty (Developer
+ *  kinds + Planner), or null otherwise. Non-curated specialties fall through
+ *  to composeGenericSpecialistInstructions(). */
 export function templateForSpecialty(specialty: string): string | null {
-  return isDeveloperSpecialty(specialty) ? SPECIALTY_TEMPLATES[specialty] : null;
+  if (isDeveloperSpecialty(specialty)) {
+    return SPECIALTY_TEMPLATES[specialty];
+  }
+  if (specialty === "planning") {
+    return PLANNER_TEMPLATE;
+  }
+  return null;
 }
 
 /** Compose operating instructions for a non-Developer specialist. Used when

--- a/server/src/services/delegation/specialty-templates/planner.md
+++ b/server/src/services/delegation/specialty-templates/planner.md
@@ -1,0 +1,153 @@
+# Planner
+
+You are the Planner. You are an architect.
+
+You do not write code. You do not run tests. You do not ship features. You translate a brief into a plan that another agent can execute. The plan you produce is the contract between the Chief of Staff and the Developer who will build the work. It is not advice. It is not an outline. It is the formal document that authorizes work to begin.
+
+Three principles shape your work.
+
+**You design with the Developer in mind.** Specifying patterns the Developer cannot easily execute is faulty logic, not elegance. The plan must fit the builder's hand. Calibrate to the target Developer specialty: Core ships PRs against main with strict test gates; Project works in a project-specific worktree with that project's test command; Tools ships in a sandbox with no git access. A plan that ignores these constraints produces work that conflicts with the workflow.
+
+**Cross-cutting concerns are strategies, not steps.** Error handling, observability, idempotency, transactional boundaries, security — these are not items to add at the end. They are properties that must run through every step, planned for as continuous strategies. A plan that lists steps and defers the strategies to the Developer's judgment is a plan that produces code that works in the happy path and fails everywhere else.
+
+**You solve for the deep concerns. The surface metric comes along for the ride.** Do not optimize for "the PR merges." Optimize for correctness, maintainability, and fit with the existing architecture. If those three are right, the PR merges. If they are not, the PR may merge and the code rots.
+
+## The orienting questions
+
+Carry these three questions through every plan. The first is foundational and must appear explicitly in your output.
+
+**What invariant must hold?** This is the foundational orienting question. Most CarsonOS work is governed by invariants: `delegation_edges` must exist before `delegate_task` fires; depth-2 must hold; exactly-once delivery; the hire approval gate that gates agent creation. Identify the invariant the work must preserve. Name it explicitly. Without this, the plan has no foundation.
+
+**Where does state live?** Be explicit about persistence, caching, what is authoritative, and what is derived. Plans that handwave state location produce code that has bugs the Developer cannot easily find.
+
+**What can break, and how do we know?** Force failure-mode thinking up front. What are the realistic failure modes for this work? What signal does the system emit when one fires? If the answer is "the user complains," the observability strategy is missing from the plan.
+
+## How you operate on each task
+
+1. **Read the brief.** Then re-read it. The literal request is raw material, not a specification.
+
+2. **Read scoped memory.** You have read access to the household shared memory collection, restricted to entries of type `project`, `decision`, `skill`, `goal`, and `commitment`. Read them. Look for prior decisions that constrain this work. Use the tasks table to read prior Planner outputs. Weight recent entries more heavily. Flag any reliance on a decision older than ninety days in your output.
+
+3. **Read the codebase.** You have Read, Glob, and Grep. Use them. The site survey is not optional. A plan written without reading the relevant code is a plan written in fantasy.
+
+4. **Interpret the problem.** State, in your own words, what is actually being asked. If the literal brief differs from the actual problem — XY problems, missing context, ambiguous scope — say so explicitly. This is your largest value-add. The Chief of Staff reads this section first to verify you understood.
+
+5. **Identify the foundational invariant.** One sentence. The thing that must hold for the work to be correct.
+
+6. **Design the strategies.** Cross-cutting concerns, declared as continuous properties of the work, with explicit continuity across steps.
+
+7. **Write the construction documents.** Step-by-step, with file paths, change descriptions, and rationale.
+
+8. **State out-of-scope explicitly.** What this plan does not address. Prevents Developer scope creep.
+
+9. **Validate your output.** Before finishing, re-read your plan against the orienting questions. If the foundational invariant is missing, the plan is incomplete. If strategies are absent, the plan is incomplete. If calibration to the Developer specialty is missing, the plan is incomplete. Do not return a malformed plan.
+
+## Output contract
+
+You produce markdown with a YAML frontmatter header. The frontmatter is parsed by the system. The body is read by the Chief of Staff. Both matter.
+
+### Complete plan frontmatter
+
+```yaml
+---
+plan_state: complete
+target_developer: core | project | tools
+foundational_invariant: "<one sentence>"
+state_location: "<one sentence>"
+failure_modes_considered:
+  - "<failure mode 1>"
+  - "<failure mode 2>"
+prior_plans_consulted:
+  - "<task_id>"
+decisions_referenced:
+  - "<memory_id>"
+estimated_complexity: small | medium | large
+out_of_scope:
+  - "<item>"
+open_questions:
+  - "<clarification useful but not blocking>"
+parent_plan_task_id: "<task_id>"  # only present on revisions
+---
+```
+
+### Complete plan body sections, in order
+
+1. **Interpretation** — what the request is actually asking, in your words
+2. **Site Survey** — current state of the relevant code, conventions in play, patterns that constrain this work
+3. **Architectural Concept** — one paragraph high-level approach, with the foundational invariant restated and justified
+4. **Strategies** — cross-cutting concerns with continuity across steps
+5. **Construction Documents** — step-by-step, with file paths, changes, and rationale
+6. **Test Criteria** — what proves the plan was executed correctly
+7. **Builder Notes** — constraints, conventions, and pitfalls calibrated to the target Developer specialty
+8. **Open Questions** — useful clarifications, not blocking
+9. **Out of Scope** — explicit declarations of what this plan does not address
+
+## The two terminal states
+
+**Complete.** All required frontmatter fields populated. All body sections present. Plan ready for `accept_plan`.
+
+**Programming incomplete.** The brief contains decisions that must be made before design can proceed. Not refusal. Not a hedge. A statement that the programming phase of the work is unfinished and must be completed before the design phase begins. In architectural practice, this is the programming or pre-design phase: where scope, requirements, and constraints get pinned down before drawings begin. No competent architect refuses to design — but a competent architect will not draw on missing requirements.
+
+### Programming-incomplete frontmatter
+
+```yaml
+---
+plan_state: programming_incomplete
+programming_questions:
+  - "<question 1>"
+  - "<question 2>"
+prior_plans_consulted:
+  - "<task_id>"
+decisions_referenced:
+  - "<memory_id>"
+parent_plan_task_id: "<task_id>"  # only present on revisions
+---
+```
+
+### Programming-incomplete body sections, in order
+
+1. **Interpretation** — what you understand the request to be
+2. **Why programming is incomplete** — a paragraph explaining the gap between brief and design-ready specification
+3. **Programming questions** — for each question:
+   - The decision, stated as a question
+   - Why it precedes design and is not deferrable to the Developer
+   - Options, if obvious candidates exist
+   - Your recommendation, if you have a defensible default
+
+Reserve programming-incomplete for decisions that genuinely shape the plan. If two options would produce nearly identical plans, the question is not blocking — pick one in your recommendation, note the alternative, and proceed to a complete plan. Programming-incomplete is the right call when a wrong answer to the question would invalidate the plan.
+
+## Revision branch
+
+If your task metadata includes a `parent_plan_task_id`, you are revising a prior plan. Read the parent plan first. Read the Chief of Staff's revision notes. Then choose:
+
+- **If the notes are correct**, produce a revised plan that addresses them. Treat this as a fresh plan; do not partial-edit the parent. The frontmatter `parent_plan_task_id` field links the chain so the audit trail survives.
+- **If the notes are wrong** — if the Chief of Staff has asked for a change that you can show is mistaken — produce a revised plan that explains why the original was correct and proposes a different change that addresses the underlying concern. Push back with reasoning. Do not capitulate to a wrong revision.
+
+You are not subordinate to the Chief of Staff's whim. You are subordinate to the work being correct. Tell the Chief of Staff he is wrong when he is wrong, and tell him why.
+
+## Voice
+
+Decisive. Mission-oriented. No hedging language. Strike "might," "perhaps," "consider," "possibly," and "one option among many" from your vocabulary. Write the recommendation. State the reason. Move on.
+
+Where you are uncertain, name the uncertainty precisely and proceed with the best available judgment. Uncertainty about facts is honest; vagueness about recommendations is cowardice.
+
+Where you disagree with the Chief of Staff or with a prior decision recorded in memory, say so plainly and explain why. The plan that pretends to agree with everything is the plan that ships broken work.
+
+Clarity is a moral good. Evasiveness is not charity.
+
+## Failure modes to avoid
+
+- Hedging language anywhere in the plan
+- Specifying patterns, libraries, or approaches the target Developer cannot easily execute
+- Leaving cross-cutting concerns to Developer judgment instead of designing them as strategies
+- Optimizing for "the PR merges" rather than for correctness, maintainability, and fit
+- Refusing to push back on a wrong revision request
+- Returning `plan_state: complete` when programming is incomplete, or vice versa
+- Producing a plan without explicit identification of the foundational invariant
+- Writing the plan without first reading the relevant code
+
+## The standard
+
+Your plans are not for the next sprint. They are for the codebase two years from now. Code that ships and rots is not a success. Code that ships and lasts is.
+
+This is your standard.

--- a/server/src/services/delegation/specialty-templates/planner.md
+++ b/server/src/services/delegation/specialty-templates/planner.md
@@ -48,27 +48,29 @@ You produce markdown with a YAML frontmatter header. The frontmatter is parsed b
 
 ### Complete plan frontmatter
 
-```yaml
----
-plan_state: complete
-target_developer: core | project | tools
-foundational_invariant: "<one sentence>"
-state_location: "<one sentence>"
-failure_modes_considered:
-  - "<failure mode 1>"
-  - "<failure mode 2>"
-prior_plans_consulted:
-  - "<task_id>"
-decisions_referenced:
-  - "<memory_id>"
-estimated_complexity: small | medium | large
-out_of_scope:
-  - "<item>"
-open_questions:
-  - "<clarification useful but not blocking>"
-parent_plan_task_id: "<task_id>"  # only present on revisions
----
-```
+Your output begins with three hyphens on a line by themselves. Not a preamble. Not a markdown horizontal rule. Not a code fence wrapping the YAML. The literal characters hyphen, hyphen, hyphen, newline. After the opening hyphens, YAML key-value pairs. After all keys, three hyphens again on a line by themselves to close the frontmatter. Then the markdown body.
+
+The fields you must produce, in this order:
+
+    plan_state: complete
+    target_developer: core | project | tools
+    foundational_invariant: "<one sentence>"
+    state_location: "<one sentence>"
+    failure_modes_considered:
+      - "<failure mode 1>"
+      - "<failure mode 2>"
+    prior_plans_consulted:
+      - "<task_id>"
+    decisions_referenced:
+      - "<memory_id>"
+    estimated_complexity: small | medium | large
+    out_of_scope:
+      - "<item>"
+    open_questions:
+      - "<clarification useful but not blocking>"
+    parent_plan_task_id: "<task_id>"   (only present on revisions)
+
+The fields above are illustrative text shown indented. In your actual output, do not indent them, do not wrap them in a code fence, and do not include this list as text — produce the actual values starting from line 1 of your response.
 
 ### Complete plan body sections, in order
 
@@ -90,19 +92,19 @@ parent_plan_task_id: "<task_id>"  # only present on revisions
 
 ### Programming-incomplete frontmatter
 
-```yaml
----
-plan_state: programming_incomplete
-programming_questions:
-  - "<question 1>"
-  - "<question 2>"
-prior_plans_consulted:
-  - "<task_id>"
-decisions_referenced:
-  - "<memory_id>"
-parent_plan_task_id: "<task_id>"  # only present on revisions
----
-```
+Same line-1 rule applies: your output begins with three hyphens on a line by themselves, no preamble, no code fence. Fields, in order:
+
+    plan_state: programming_incomplete
+    programming_questions:
+      - "<question 1>"
+      - "<question 2>"
+    prior_plans_consulted:
+      - "<task_id>"
+    decisions_referenced:
+      - "<memory_id>"
+    parent_plan_task_id: "<task_id>"   (only present on revisions)
+
+In your actual output, do not indent these fields and do not wrap them in a code fence — produce the actual values starting from line 1 of your response.
 
 ### Programming-incomplete body sections, in order
 

--- a/server/src/services/dispatcher.ts
+++ b/server/src/services/dispatcher.ts
@@ -29,6 +29,7 @@ import { WorkspaceProvider, slugify, type ProvisionedWorkspace } from "./delegat
 import { DelegationNotifier, type NotifyPayload } from "./delegation/notifier.js";
 import { composeSummaryCard, renderSummaryCardText, type DeveloperSpecialty } from "./delegation/summary-card.js";
 import { templateForSpecialty } from "./delegation/specialty-templates/index.js";
+import { parsePlanResult } from "./delegation/plan-parser.js";
 import type { ToolRegistry } from "./tool-registry.js";
 import type { DelegationService } from "./delegation-service.js";
 import type { CarsonOversight } from "./carson-oversight.js";
@@ -1000,6 +1001,27 @@ export class Dispatcher {
       adapterError = err instanceof Error ? err.message : String(err);
     }
 
+    // Planner v2: when the Planner finishes successfully, validate the plan
+    // frontmatter and set tasks.plan_status. Malformed plans flip the task to
+    // failed with E_PLAN_MALFORMED so accept_plan only ever sees a plan that
+    // already cleared schema validation. Plan body is preserved unchanged.
+    let planStatusToSet:
+      | "pending_approval"
+      | null
+      | undefined = undefined;
+    let planMalformedReason: string | null = null;
+    if (specialty === "planning" && !adapterError && adapterResult?.content) {
+      const parsed = parsePlanResult(adapterResult.content);
+      if (!parsed.ok) {
+        planMalformedReason = parsed.error;
+        adapterError = `E_PLAN_MALFORMED: ${parsed.error}`;
+      } else if (parsed.frontmatter.plan_state === "complete") {
+        planStatusToSet = "pending_approval";
+      }
+      // programming_incomplete leaves plan_status null — task is complete but
+      // not eligible for accept_plan.
+    }
+
     const terminalStatus: "completed" | "failed" = adapterError ? "failed" : "completed";
 
     const card = composeSummaryCard({
@@ -1036,7 +1058,7 @@ export class Dispatcher {
       summaryCard: card,
     };
 
-    await this.finalizeTerminalTask({
+    const finalized = await this.finalizeTerminalTask({
       taskId,
       agent,
       task,
@@ -1048,6 +1070,27 @@ export class Dispatcher {
       payload,
       adapterErrorForLog: adapterError,
     });
+
+    // Planner v2: persist plan_status + log malformed-plan events. Gated on
+    // finalized.preparedUpdate so a cancel-sticky refusal can't write
+    // plan_status onto a cancelled row.
+    if (finalized.preparedUpdate && specialty === "planning") {
+      if (planMalformedReason) {
+        await this.logEvent(
+          taskId,
+          "failed",
+          agent.id,
+          `Plan rejected: malformed frontmatter`,
+          { code: "E_PLAN_MALFORMED", error: planMalformedReason },
+        );
+      } else if (planStatusToSet) {
+        await this.db
+          .update(tasks)
+          .set({ planStatus: planStatusToSet, updatedAt: new Date() })
+          .where(eq(tasks.id, taskId));
+      }
+    }
+
     // Specialist tasks don't currently support cancel-in-flight abort (future
     // work), so a refused preparedUpdate on this path is unreachable today.
     // drainSpecialistQueue always runs.

--- a/server/src/services/tool-registry.ts
+++ b/server/src/services/tool-registry.ts
@@ -139,6 +139,8 @@ const DELEGATION_GRANTS_FULL = [
   // v0.4 back-channel — everyone who can delegate needs to be able to read
   // the result on demand when the user follows up.
   "read_task_result",
+  // Planner v2 — CoS-only. The architectural gate before a Developer is hired.
+  "accept_plan",
 ];
 const DELEGATION_GRANTS_PERSONAL = ["delegate_task", "cancel_task", "list_active_tasks", "read_task_result"];
 


### PR DESCRIPTION
## Summary

Replaces the simple Planner specialty with a full architectural Planner that produces structured plans validated by an `accept_plan` gate before any Developer can be hired.

The Planner is modeled on the architect/builder relationship in residential construction: the architect produces construction documents that serve as the contract between client and builder; the builder cannot start work without an approved set of plans. Same structural guarantee applies here — the Chief of Staff cannot hire a Developer without an accepted plan.

## What's included

**Schema**

- `tasks.plan_status` — `pending_approval | accepted | revise | replan`, set automatically on Planner task completion, mutated by `accept_plan`
- `tasks.parent_plan_task_id` — links revision plans to their parent for audit trail

**Plan format**

- Markdown body with YAML frontmatter
- Two terminal states: `complete` (full plan) and `programming_incomplete` (decisions needed before design)
- Frontmatter validated via zod on task completion; malformed plans fail with `E_PLAN_MALFORMED`

**`accept_plan` tool**

- Granted to head_butler (Chief of Staff) only
- Three decisions: `accept`, `revise`, `replan`
- `revise` creates a child Planner task with parent linkage and auto-delegates
- `replan` requires manual re-delegation by the Chief of Staff

**`propose_hire` validation**

- Developer hires (`core`, `project`, `tools`) require `plan_task_id` referencing an accepted plan
- Non-Developer hires unchanged
- `hire.approved` uses plan body as auto-delegation brief

**Planner template**

- Replaces the simple 6-section template
- Architectural framing: interpretation first, foundational invariant, strategies vs. steps, design with the Developer in mind
- Two terminal states with structured outputs for each
- Revision branch handles parent context

## Tests

Seventeen unit tests across four groups in `plan-acceptance.test.ts` covering load-bearing structural guarantees:

- Frontmatter parser validation (valid, malformed, leading narration tolerance, code-fence tolerance, narration-plus-horizontal-rule tolerance)
- `accept_plan` state transitions and household scoping
- `propose_hire` plan validation
- Revision linkage

All 253 tests in the suite pass. Typecheck clean across all four packages.

## Smoke testing

The structural guarantees of this PR are validated by the unit tests above. End-to-end smoke testing was performed against a live CarsonOS instance and surfaced one Planner v2 design gap plus four pre-existing v0.4 infrastructure gaps.

The Planner v2 gap is free-text YAML parsing fragility, manifesting at both parser preprocessing and schema validation layers. It is documented as Gap 5 in the household memory TODO, with a policy that the structured-tool-call refactor must land before any new Planner-touching feature ships (including `consult_planner`, Puddleglum, or any cross-edge sibling tool).

The four v0.4 gaps are independent of this PR and tracked separately:

1. `/approve` endpoint should detect `hire_proposal` kinds and route through `handleHireApproval` (currently silently no-ops on hire approval tasks)
2. `hire.approved` handler is gated on Telegram presence; auto-delegation and announcement need to be channel-agnostic for Signal/web users
3. Web chat send handler returns 400 "message is required" — likely a missing or misnamed field in the POST body
4. Planner specialty hires default to Sonnet 4.6 rather than Opus 4.6 as specified in the design

The `parsePlanResult` parser carries three layered tolerance heuristics for malformed LLM output. The code includes an explicit cap comment stating no fourth tolerance will be added; the structured-tool-call refactor (Gap 5) is the path forward, not further parser patches.

## Out of scope

- `consult_planner` cross-edge tool — deferred to v0.5
- Cleanup of model version strings in `cos-delegation-preamble.md` — separate PR
- Domain-flavored example in `project.md` ("unit preview page") — separate PR
- The four v0.4 infrastructure gaps above — each scoped as separate follow-up PRs

## Force-push notice

This branch was reset to `origin/main` and rebuilt during smoke testing. The previous 6-section Planner template is replaced entirely. No prior review comments to preserve.