### PR TITLE
chore: gitignore CONTEXT.md (personal session state)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist/
 .gstack/
 .playwright-mcp/
 .claude/
+CONTEXT.md
 
 # Local test/smoke-test scripts
 scripts/test-*.ts


### PR DESCRIPTION
Adds CONTEXT.md to .gitignore. The file is referenced in project conventions as gitignored but was not actually in any ignore mechanism — a stray `git add .` would catch it. This closes that gap.

One-line change. No code impact.