### PR TITLE
fix(staff): default head butler to full trust on creation

### DIFF
--- a/server/src/routes/staff.ts
+++ b/server/src/routes/staff.ts
@@ -188,7 +188,7 @@ export function createStaffRoutes(deps: StaffRouteDeps): Router {
         signalAccount: req.body.signal_account ?? null,
         signalDaemonPort: req.body.signal_daemon_port ?? null,
         model: model ?? "claude-sonnet-4-6",
-        trustLevel: trustLevel ?? "restricted",
+        trustLevel: trustLevel ?? (isHeadButler ? "full" : "restricted"),
         isHeadButler: isHeadButler ?? false,
         autonomyLevel: autonomyLevel ?? "supervised",
       })


### PR DESCRIPTION
## Summary

The generic `POST /api/staff` route was forcing every new agent to `trust_level = restricted` unless the caller passed `trustLevel` explicitly. Head butlers (Chief of Staff) created via this path landed without Bash, Write, Edit, or Skill — blocking dependency installs and other admin work the role exists to handle.

Onboarding's own seeding path already creates head butlers at `full` trust (\`routes/onboarding.ts:221\`), so this only patches the fallback flow that everything else uses.

## Why this matters

Surfaced tonight when Carson (head butler) needed to \`pip3 install\` Python packages for music tools the Dev specialty had just built for Grant's agent. Carson tried to grant itself Bash and reported "Bash isn't a grantable built-in for me" — which is correct: Bash is gated by \`trust_level\`, and Carson was at \`standard\` instead of \`full\`.

## Change

\`\`\`diff
- trustLevel: trustLevel ?? "restricted",
+ trustLevel: trustLevel ?? (isHeadButler ? "full" : "restricted"),
\`\`\`

One line at \`server/src/routes/staff.ts:191\`. Non-head-butler agents still default to \`restricted\` — the explicit-pass path is unchanged.

## Test plan

- [ ] Existing agents are unaffected (this only changes the default for *new* head butlers created without explicit \`trustLevel\` in the request body)
- [ ] Existing Carson on the live instance was bumped to \`full\` via direct DB update — separate, manual fix
- [ ] Confirm a fresh head-butler creation through this endpoint comes back with \`trust_level: "full"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)