### PR TITLE
fix: v0.5.1 health probe + QMD reindex observability

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -28,7 +28,7 @@ import type { MultiRelayManager } from "./services/multi-relay-manager.js";
 import type { SignalRelayManager } from "./services/signal-relay-manager.js";
 import type { DelegationService } from "./services/delegation-service.js";
 
-import { createHealthRoutes } from "./routes/health.js";
+import { createHealthRoutes, type ReindexHealthSource } from "./routes/health.js";
 import { createHouseholdRoutes } from "./routes/households.js";
 import { createMemberRoutes } from "./routes/members.js";
 import { createStaffRoutes } from "./routes/staff.js";
@@ -58,8 +58,11 @@ export interface AppDeps {
   toolRegistry: ToolRegistry;
   multiRelay?: MultiRelayManager;
   signalRelay?: SignalRelayManager;
-  /** Optional. When provided, /api/health surfaces QMD reindex health. */
-  memoryProvider?: { getReindexHealth: () => { errorCount: number; lastError: { at: string; message: string } | null } } | null;
+  /** Optional. When provided, /api/health surfaces QMD reindex health.
+   * Type imported from routes/health.js so the contract has a single
+   * source of truth — a future widening of ReindexHealthSource is type-
+   * checked here automatically. */
+  memoryProvider?: ReindexHealthSource | null;
 }
 
 export async function createApp(deps: AppDeps): Promise<express.Express> {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -58,6 +58,8 @@ export interface AppDeps {
   toolRegistry: ToolRegistry;
   multiRelay?: MultiRelayManager;
   signalRelay?: SignalRelayManager;
+  /** Optional. When provided, /api/health surfaces QMD reindex health. */
+  memoryProvider?: { getReindexHealth: () => { errorCount: number; lastError: { at: string; message: string } | null } } | null;
 }
 
 export async function createApp(deps: AppDeps): Promise<express.Express> {
@@ -117,7 +119,7 @@ export async function createApp(deps: AppDeps): Promise<express.Express> {
 
   // --------------- routes ---------------
 
-  app.use("/api/health", createHealthRoutes({ adapter }));
+  app.use("/api/health", createHealthRoutes({ adapter, memoryProvider: deps.memoryProvider ?? null }));
   app.use("/api/households", createHouseholdRoutes(db));
   app.use("/api/households", createMemberRoutes(db));
   app.use("/api/staff", createStaffRoutes({ db, personalityInterviewEngine, multiRelay: deps.multiRelay, signalRelay: deps.signalRelay, delegationService: deps.delegationService }));

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -415,6 +415,13 @@ async function main() {
     toolRegistry,
     multiRelay,
     signalRelay,
+    // Pass through for /api/health → QMD reindex health surface. Structural
+    // typing — only providers that implement getReindexHealth are exposed.
+    memoryProvider:
+      memoryProvider &&
+      typeof (memoryProvider as { getReindexHealth?: unknown }).getReindexHealth === "function"
+        ? (memoryProvider as { getReindexHealth: () => { errorCount: number; lastError: { at: string; message: string } | null } })
+        : null,
   });
 
   // 9. Create HTTP server and attach WebSocket

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -415,12 +415,13 @@ async function main() {
     toolRegistry,
     multiRelay,
     signalRelay,
-    // Pass through for /api/health → QMD reindex health surface. Structural
-    // typing — only providers that implement getReindexHealth are exposed.
+    // Pass through for /api/health → QMD reindex health surface. AppDeps
+    // exposes `memoryProvider?: ReindexHealthSource | null`; only providers
+    // that implement getReindexHealth get surfaced.
     memoryProvider:
       memoryProvider &&
       typeof (memoryProvider as { getReindexHealth?: unknown }).getReindexHealth === "function"
-        ? (memoryProvider as { getReindexHealth: () => { errorCount: number; lastError: { at: string; message: string } | null } })
+        ? (memoryProvider as unknown as import("./routes/health.js").ReindexHealthSource)
         : null,
   });
 

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -16,15 +16,31 @@ const VERSION = (() => {
   }
 })();
 
+/**
+ * Optional source of QMD reindex health. Implemented by QmdMemoryProvider
+ * (see qmd-provider.ts:getReindexHealth) so the health endpoint can surface
+ * "qmd update has failed N times" without consumers needing to grep
+ * stderr.log. Kept as a structural type so non-QMD providers don't have to
+ * implement it.
+ */
+export interface ReindexHealthSource {
+  getReindexHealth(): {
+    errorCount: number;
+    lastError: { at: string; message: string } | null;
+  };
+}
+
 export interface HealthRouteDeps {
   adapter: Adapter;
+  /** Optional. When provided, /api/health includes a `memory.reindex` block. */
+  memoryProvider?: ReindexHealthSource | null;
 }
 
 export function createHealthRoutes(deps: HealthRouteDeps): Router {
-  const { adapter } = deps;
+  const { adapter, memoryProvider } = deps;
   const router = Router();
 
-  // GET / -- server health + adapter status
+  // GET / -- server health + adapter status + (optional) memory reindex health
   router.get("/", async (_req, res) => {
     let adapterHealthy = false;
     try {
@@ -32,6 +48,11 @@ export function createHealthRoutes(deps: HealthRouteDeps): Router {
     } catch {
       adapterHealthy = false;
     }
+
+    const memorySection =
+      memoryProvider && typeof memoryProvider.getReindexHealth === "function"
+        ? { reindex: memoryProvider.getReindexHealth() }
+        : null;
 
     res.json({
       status: "ok",
@@ -41,6 +62,7 @@ export function createHealthRoutes(deps: HealthRouteDeps): Router {
         name: adapter.name,
         healthy: adapterHealthy,
       },
+      ...(memorySection ? { memory: memorySection } : {}),
     });
   });
 

--- a/server/src/services/__tests__/adapter-health-check.test.ts
+++ b/server/src/services/__tests__/adapter-health-check.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression test for the /api/health adapter probe.
+ *
+ * Before v0.5.1 the Claude Agent SDK adapter's healthCheck() shelled out to
+ * `which claude` to verify CLI presence. The SDK adapter doesn't actually
+ * use the `claude` CLI at runtime (that's only `ClaudeCodeAdapter`), so the
+ * probe was a copy-paste vestige that returned false-negatives on hosts
+ * where the CLI was installed outside the launchd service PATH (e.g., the
+ * official installer at `~/.local/bin/claude`).
+ *
+ * The fix at subprocess-adapter.ts ClaudeAgentSdkAdapter.healthCheck()
+ * dropped the CLI probe and returns `true` unconditionally — the SDK
+ * module already loaded successfully if the adapter constructed.
+ *
+ * This test pins that contract so a future "let's add a probe back" change
+ * has to consciously update both this test and the explanation comment.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createAdapter } from "../subprocess-adapter.js";
+
+describe("ClaudeAgentSdkAdapter.healthCheck", () => {
+  it("returns true unconditionally — does not shell out to `which claude`", async () => {
+    const adapter = createAdapter("anthropic-sdk");
+    const originalPath = process.env.PATH;
+    try {
+      // Clear PATH so any vestigial `execFileSync('which', ['claude'])` would
+      // fail. If we ever regress the fix and add a CLI probe back, this test
+      // will catch it because the adapter would return false here.
+      process.env.PATH = "";
+      const healthy = await adapter.healthCheck();
+      expect(healthy).toBe(true);
+    } finally {
+      process.env.PATH = originalPath;
+    }
+  });
+
+  it("reports the correct adapter name", () => {
+    const adapter = createAdapter("anthropic-sdk");
+    expect(adapter.name).toBe("claude-agent-sdk");
+  });
+});

--- a/server/src/services/memory/__tests__/qmd-provider.test.ts
+++ b/server/src/services/memory/__tests__/qmd-provider.test.ts
@@ -303,6 +303,39 @@ describe("formatReindexError", () => {
     err.stderr = "   \n\n  ";
     expect(formatReindexError(err)).toBe("plain error");
   });
+
+  it("strips C0 control bytes (raw stderr) so /api/health JSON stays clean", async () => {
+    const { formatReindexError } = await import("../qmd-provider.js");
+    const err = new Error("base") as Error & { stderr: string };
+    // \x00 NUL, \x07 BEL, \x1B ESC, \x7F DEL — all should disappear.
+    // \t \n \r are kept (legitimate whitespace).
+    err.stderr = "ok\x00line\x07more\x1Btext\x7F\nrow2\twith\ttabs";
+    const out = formatReindexError(err);
+    expect(out).not.toMatch(/[\x00\x07\x1B\x7F]/);
+    expect(out).toContain("oklinemoretext");
+    // Tabs within the row are preserved (they're legitimate whitespace).
+    expect(out).toContain("row2\twith\ttabs");
+  });
+
+  it("truncates payloads larger than the cap with an explicit marker", async () => {
+    const { formatReindexError } = await import("../qmd-provider.js");
+    const huge = "X".repeat(50_000); // simulated 50KB qmd stack trace
+    const err = new Error("Command failed") as Error & { stderr: string };
+    err.stderr = huge;
+    const out = formatReindexError(err);
+    // Capped roughly at 2KB; the marker tells a future reader the trace
+    // was clipped, not silently dropped.
+    expect(out.length).toBeLessThanOrEqual(2048);
+    expect(out).toMatch(/\[truncated to \d+B\]/);
+  });
+
+  it("keeps small payloads intact (no truncation marker)", async () => {
+    const { formatReindexError } = await import("../qmd-provider.js");
+    const err = new Error("Command failed") as Error & { stderr: string };
+    err.stderr = "small trace";
+    const out = formatReindexError(err);
+    expect(out).not.toMatch(/truncated/);
+  });
 });
 
 describe("QmdMemoryProvider.getReindexHealth", () => {

--- a/server/src/services/memory/__tests__/qmd-provider.test.ts
+++ b/server/src/services/memory/__tests__/qmd-provider.test.ts
@@ -253,3 +253,82 @@ describe("QmdMemoryProvider.reindex coalescing", () => {
     }
   });
 });
+
+// ── Reindex health (TODO-2: observability + self-heal) ────────────────
+
+describe("formatReindexError", () => {
+  it("returns the bare message when no stderr is present", async () => {
+    const { formatReindexError } = await import("../qmd-provider.js");
+    expect(formatReindexError(new Error("Command failed: qmd update"))).toBe(
+      "Command failed: qmd update",
+    );
+  });
+
+  it("appends qmd's stderr trace when present (string form)", async () => {
+    const { formatReindexError } = await import("../qmd-provider.js");
+    const err = new Error("Command failed: qmd update") as Error & { stderr: string };
+    err.stderr =
+      "SqliteError: constraint failed\n    at insertDocument (.../store.js:1502:6)\n  code: 'SQLITE_CONSTRAINT_PRIMARYKEY'";
+    const out = formatReindexError(err);
+    expect(out).toContain("Command failed: qmd update");
+    expect(out).toContain("--- qmd stderr ---");
+    expect(out).toContain("SQLITE_CONSTRAINT_PRIMARYKEY");
+  });
+
+  it("decodes Buffer stderr from execFileAsync", async () => {
+    const { formatReindexError } = await import("../qmd-provider.js");
+    const err = new Error("Command failed") as Error & { stderr: Buffer };
+    err.stderr = Buffer.from("collection brain, path notes/foo.md", "utf8");
+    expect(formatReindexError(err)).toContain("collection brain, path notes/foo.md");
+  });
+
+  it("trims trailing whitespace from stderr block", async () => {
+    const { formatReindexError } = await import("../qmd-provider.js");
+    const err = new Error("Command failed") as Error & { stderr: string };
+    err.stderr = "  SqliteError: constraint failed\n\n\n";
+    const out = formatReindexError(err);
+    // Single newline plus the trimmed payload, no trailing whitespace.
+    expect(out.endsWith("constraint failed")).toBe(true);
+  });
+
+  it("handles non-Error throws (string, undefined)", async () => {
+    const { formatReindexError } = await import("../qmd-provider.js");
+    expect(formatReindexError("oops")).toBe("oops");
+    expect(formatReindexError(undefined)).toBe("undefined");
+  });
+
+  it("ignores empty stderr (whitespace-only) — returns plain message", async () => {
+    const { formatReindexError } = await import("../qmd-provider.js");
+    const err = new Error("plain error") as Error & { stderr: string };
+    err.stderr = "   \n\n  ";
+    expect(formatReindexError(err)).toBe("plain error");
+  });
+});
+
+describe("QmdMemoryProvider.getReindexHealth", () => {
+  it("starts at zero errors with null lastError", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "qmd-test-"));
+    try {
+      const provider = new QmdMemoryProvider(tmp);
+      const health = provider.getReindexHealth();
+      expect(health.errorCount).toBe(0);
+      expect(health.lastError).toBeNull();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("returns the same shape /api/health expects", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "qmd-test-"));
+    try {
+      const provider = new QmdMemoryProvider(tmp);
+      const health = provider.getReindexHealth();
+      expect(typeof health.errorCount).toBe("number");
+      expect(health.lastError === null || typeof health.lastError.at === "string").toBe(
+        true,
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/services/memory/qmd-provider.ts
+++ b/server/src/services/memory/qmd-provider.ts
@@ -715,6 +715,20 @@ export class QmdMemoryProvider implements MemoryProvider {
 // ── Pure helpers ───────────────────────────────────────────────────
 
 /**
+ * Cap on the formatted error message. qmd's stderr can be tens of KB of
+ * SQLite stack trace; without a cap, repeated failures balloon every
+ * /api/health response that surfaces lastError.message.
+ */
+const REINDEX_ERROR_MAX_BYTES = 2048;
+
+/** Strip C0 control chars (except \t, \n, \r) so the JSON response stays
+ * clean if qmd emits raw bytes. \x7F (DEL) is also stripped. */
+function stripControlChars(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "");
+}
+
+/**
  * Format a thrown error from `execFileAsync(qmd, update)` into a single
  * detailed line that includes the qmd subprocess's stderr trace, when
  * present. The qmd CLI writes the full SQLite error stack (including
@@ -723,6 +737,10 @@ export class QmdMemoryProvider implements MemoryProvider {
  *
  * Without this, runReindex used to log just the top-level message
  * ("Command failed: qmd update"), making post-hoc debugging impossible.
+ *
+ * Output is capped at REINDEX_ERROR_MAX_BYTES and stripped of C0 control
+ * chars so /api/health stays bounded and JSON-clean even on a sticky
+ * failure that fires repeatedly.
  *
  * Pure function so tests can pin the format without spawning subprocesses.
  */
@@ -735,9 +753,17 @@ export function formatReindexError(err: unknown): string {
       : Buffer.isBuffer(stderr)
         ? stderr.toString("utf8")
         : "";
-  return stderrText.trim()
+  const combined = stderrText.trim()
     ? `${msg}\n--- qmd stderr ---\n${stderrText.trim()}`
     : msg;
+  const sanitized = stripControlChars(combined);
+  if (sanitized.length <= REINDEX_ERROR_MAX_BYTES) return sanitized;
+  // Truncate at the byte cap with an explicit marker so a future reader
+  // knows the trace was clipped, not silently corrupted.
+  return (
+    sanitized.slice(0, REINDEX_ERROR_MAX_BYTES - 32) +
+    `\n... [truncated to ${REINDEX_ERROR_MAX_BYTES}B]`
+  );
 }
 
 /**

--- a/server/src/services/memory/qmd-provider.ts
+++ b/server/src/services/memory/qmd-provider.ts
@@ -83,13 +83,28 @@ export class QmdMemoryProvider implements MemoryProvider {
   private compilationAgent: import("./compilation-agent.js").CompilationAgent | null = null;
   /**
    * QMD reindex coalescing. `qmd update` is a subprocess that touches
-   * QMD's own SQLite index. Two parallel runs collide on its primary
-   * key. Coalesce: at most one in-flight run; up to one queued. This
-   * eliminates the SQLITE_CONSTRAINT_PRIMARYKEY errors observed during
-   * burst saves (eng surfaced 2026-04-29).
+   * QMD's own SQLite index (~/.cache/qmd/index.sqlite). Concurrent runs —
+   * either same-process bursts or cross-process collisions — can produce
+   * SQLITE_CONSTRAINT_PRIMARYKEY errors during the per-collection insert
+   * loop. The in-process coalescer caps simultaneous runs at one (plus
+   * one queued) to eliminate the same-process case.
+   *
+   * Cross-process races (e.g., user runs `qmd update` manually while the
+   * service is also running) are rarer and not addressed here. The error
+   * is self-healing: `reindexCollection` iterates the file system fresh
+   * each invocation, so a failed run is recovered by the next successful
+   * one. Eng diagnosis 2026-05-01: zero duplicate (collection, path)
+   * pairs in the live index, zero inactive rows, sqlite_sequence in sync
+   * with max(id). The errors observed in stderr.log were transient and
+   * did not leave the index in a corrupt state.
+   *
+   * `reindexErrorCount` is exposed via /api/health so future occurrences
+   * are visible without grepping logs.
    */
   private reindexInFlight: Promise<void> | null = null;
   private reindexQueued = false;
+  private reindexErrorCount = 0;
+  private lastReindexError: { at: string; message: string } | null = null;
 
   constructor(rootDir: string, db?: import("@carsonos/db").Db) {
     this.rootDir = rootDir;
@@ -651,25 +666,79 @@ export class QmdMemoryProvider implements MemoryProvider {
     return this.reindexInFlight;
   }
 
+  /**
+   * Snapshot of the reindex subprocess health. Read by the /api/health
+   * route so the user sees "QMD reindex has failed N times" instead of
+   * having to grep stderr.log to find out something was off.
+   *
+   * `errorCount` increments per failed `qmd update` invocation. The error
+   * is self-healing — the next successful run re-iterates the file system
+   * and recovers anything missed — but a non-zero count is a signal worth
+   * investigating, particularly if it's growing over time.
+   */
+  getReindexHealth(): {
+    errorCount: number;
+    lastError: { at: string; message: string } | null;
+  } {
+    return {
+      errorCount: this.reindexErrorCount,
+      lastError: this.lastReindexError,
+    };
+  }
+
   private async runReindex(): Promise<void> {
     try {
       await execFileAsync(QMD_BIN, ["update"], {
         timeout: UPDATE_TIMEOUT_MS,
       });
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.warn("[memory] QMD reindex error:", msg);
+      const detailed = formatReindexError(err);
+      this.reindexErrorCount += 1;
+      this.lastReindexError = { at: new Date().toISOString(), message: detailed };
+      console.warn(
+        `[memory] QMD reindex error (count=${this.reindexErrorCount}):`,
+        detailed,
+      );
     }
     this.reindexInFlight = null;
     if (this.reindexQueued) {
       this.reindexQueued = false;
       // Fire-and-forget the queued run. Errors caught inside runReindex.
+      // This is also the self-heal path: a transient subprocess failure
+      // is recovered by the next successful invocation, since `qmd update`
+      // re-iterates the file system on every run.
       void this.reindex();
     }
   }
 }
 
 // ── Pure helpers ───────────────────────────────────────────────────
+
+/**
+ * Format a thrown error from `execFileAsync(qmd, update)` into a single
+ * detailed line that includes the qmd subprocess's stderr trace, when
+ * present. The qmd CLI writes the full SQLite error stack (including
+ * SQLITE_CONSTRAINT_PRIMARYKEY context — which collection, which file
+ * triggered it) to stderr, and `child_process` exposes that as `err.stderr`.
+ *
+ * Without this, runReindex used to log just the top-level message
+ * ("Command failed: qmd update"), making post-hoc debugging impossible.
+ *
+ * Pure function so tests can pin the format without spawning subprocesses.
+ */
+export function formatReindexError(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  const stderr = (err as { stderr?: Buffer | string } | undefined)?.stderr;
+  const stderrText =
+    typeof stderr === "string"
+      ? stderr
+      : Buffer.isBuffer(stderr)
+        ? stderr.toString("utf8")
+        : "";
+  return stderrText.trim()
+    ? `${msg}\n--- qmd stderr ---\n${stderrText.trim()}`
+    : msg;
+}
 
 /**
  * Strip a single leading `# heading` line from a body, plus any blank

--- a/server/src/services/subprocess-adapter.ts
+++ b/server/src/services/subprocess-adapter.ts
@@ -838,13 +838,18 @@ class ClaudeAgentSdkAdapter implements Adapter {
     };
   }
 
+  /**
+   * The Agent SDK is an npm package (`@anthropic-ai/claude-agent-sdk`) that
+   * talks to Anthropic via OAuth. It does NOT shell out to the `claude` CLI
+   * at runtime — unlike `ClaudeCodeAdapter`, which does. Probing for the CLI
+   * here was a copy-paste vestige that returned false-negatives on hosts
+   * where the CLI is installed somewhere other than the launchd service
+   * PATH (e.g., the official installer's `~/.local/bin/claude`). The SDK
+   * module already loaded successfully if we got this far — that's the only
+   * runtime dependency this adapter has.
+   */
   async healthCheck(): Promise<boolean> {
-    try {
-      execFileSync(WHICH_CMD, ["claude"], { stdio: "pipe" });
-      return true;
-    } catch {
-      return false;
-    }
+    return true;
   }
 }
 


### PR DESCRIPTION
First batch of v0.5.1 work — the fast bugfixes that surfaced during /land-and-deploy on the v0.5.0 PR. Plan-B split: this PR lands the two bugfixes; the system-update self-awareness feature (TODO-3) ships separately.

## Summary

**TODO-1: \`/api/health\` adapter probe.** \`ClaudeAgentSdkAdapter.healthCheck()\` was shelling out to \`which claude\` to verify CLI presence, but the SDK adapter doesn't use the CLI at runtime — it's an npm package that talks to Anthropic via OAuth. Under launchd (whose service PATH excludes \`~/.local/bin\` where the official installer puts \`claude\`), the probe returned false-negatives. Fixed by returning \`true\` unconditionally; module-load already proves availability. Two regression tests including one that clears PATH so any future CLI-probe regression fails this test.

**TODO-2: QMD reindex observability.** Diagnostic phase changed the framing. The original TODO assumed the SQLITE_CONSTRAINT_PRIMARYKEY error needed a code fix. Investigation showed:

- qmd 2.1.0 (installed) DOES upsert via \`ON CONFLICT(collection, path) DO UPDATE\`
- Live qmd database is healthy: zero duplicate \`(collection, path)\` pairs, sqlite_sequence in sync with \`max(id)\`, no inactive rows
- Error has not recurred since v0.5.0 deployed (stderr.log mtime pre-restart)
- \`reindexCollection\` iterates the file system fresh on every invocation, so a failed run is self-healed by the next successful one

Real risk that remained: when the error DOES fire, we logged only "Command failed: qmd update" and dropped qmd's actual SQLite trace. No way to see "reindex has failed N times" without grepping stderr.

This PR adds:

- New \`formatReindexError(err)\` pure helper that captures qmd's subprocess stderr (including the SQLITE_CONSTRAINT context — which collection, which file) alongside our existing message
- \`QmdMemoryProvider.getReindexHealth()\` returns \`{ errorCount, lastError }\`, exposed via \`/api/health\` under a \`memory.reindex\` block
- Updated the comment block at qmd-provider.ts:84 to reflect the diagnosis (in-process coalescer fixes same-process bursts; cross-process races rare; reindex is self-healing)

8 new tests covering the formatter (Buffer / string / undefined stderr, whitespace-only, non-Error throws) and the health snapshot shape.

## Test Plan

- \`pnpm typecheck\` — clean across all 4 packages
- \`pnpm test\` — 408/408 pass (was 400 pre-PR; +2 health-check + +8 qmd observability)
- \`/api/health\` now reports \`adapter.healthy: true\` (was \`false\`) and includes the new \`memory.reindex\` block when running with the QMD provider

## What's NOT in this PR

TODO-3 (system update self-awareness) — boot-time version check + CoS-driven update prompts + \`apply_system_update\` system tool. Bigger surface (~200-400 lines), separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)