### PR TITLE
feat: v0.5.1 system update self-awareness (CoS proposes the update)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -394,29 +394,6 @@ async function main() {
   );
   orchestrator.setAgentQueueForWake((agentId, memberId, fn) => multiRelay.enqueueAgentWork(agentId, memberId, fn));
 
-  // v0.5.1 post-restart announcement (TODO-3.5): if the previous instance
-  // wrote `system.update_pending` before restarting AND we came back up at
-  // the expected version, queue a one-shot in-voice "update applied" message
-  // from CoS to the requesting member. Fires once per boot, after multiRelay
-  // is up so the response can actually reach the user.
-  void import("./services/system-update-check.js").then(
-    ({ announceUpdateApplied }) =>
-      announceUpdateApplied(db, {
-        processMessage: (p) =>
-          constitutionEngine.processMessage({
-            ...p,
-            channel: p.channel as "telegram" | "web",
-          }),
-        sendToUser: (agentId, telegramUserId, text) =>
-          multiRelay.sendMessage(agentId, telegramUserId, text),
-      }).catch((err) =>
-        console.warn(
-          "[update-check] boot announcement failed:",
-          err instanceof Error ? err.message : String(err),
-        ),
-      ),
-  );
-
   // 7b. Signal relay (agents with signal_account + signal_daemon_port set)
   const signalRelay = new SignalRelayManager({
     db,
@@ -632,6 +609,32 @@ async function main() {
   dispatcher.replayPendingNotifications().catch((err: unknown) => {
     console.error("[engine] Phase-2 notification replay failed:", err);
   });
+
+  // v0.5.1 post-restart announcement (TODO-3.5): if the previous instance
+  // wrote `system.update_pending` before restarting AND we came back up at
+  // the expected version, queue a one-shot in-voice "update applied"
+  // message from CoS to the requesting member. Must run AFTER
+  // multiRelay.startAll() so multiRelay.sendMessage can actually reach
+  // the user — running earlier would silently fail and defer the
+  // announcement to the NEXT boot, defeating the feature on the very
+  // boot it's meant to handle.
+  void import("./services/system-update-check.js").then(
+    ({ announceUpdateApplied }) =>
+      announceUpdateApplied(db, {
+        processMessage: (p) =>
+          constitutionEngine.processMessage({
+            ...p,
+            channel: p.channel as "telegram" | "web",
+          }),
+        sendToUser: (agentId, telegramUserId, text) =>
+          multiRelay.sendMessage(agentId, telegramUserId, text),
+      }).catch((err) =>
+        console.warn(
+          "[update-check] boot announcement failed:",
+          err instanceof Error ? err.message : String(err),
+        ),
+      ),
+  );
 
   // Hourly sweep of expired hire proposals. Boot-time pass already fired
   // inside recoverStuckTasks; this catches anything that expires during a

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -394,6 +394,29 @@ async function main() {
   );
   orchestrator.setAgentQueueForWake((agentId, memberId, fn) => multiRelay.enqueueAgentWork(agentId, memberId, fn));
 
+  // v0.5.1 post-restart announcement (TODO-3.5): if the previous instance
+  // wrote `system.update_pending` before restarting AND we came back up at
+  // the expected version, queue a one-shot in-voice "update applied" message
+  // from CoS to the requesting member. Fires once per boot, after multiRelay
+  // is up so the response can actually reach the user.
+  void import("./services/system-update-check.js").then(
+    ({ announceUpdateApplied }) =>
+      announceUpdateApplied(db, {
+        processMessage: (p) =>
+          constitutionEngine.processMessage({
+            ...p,
+            channel: p.channel as "telegram" | "web",
+          }),
+        sendToUser: (agentId, telegramUserId, text) =>
+          multiRelay.sendMessage(agentId, telegramUserId, text),
+      }).catch((err) =>
+        console.warn(
+          "[update-check] boot announcement failed:",
+          err instanceof Error ? err.message : String(err),
+        ),
+      ),
+  );
+
   // 7b. Signal relay (agents with signal_account + signal_daemon_port set)
   const signalRelay = new SignalRelayManager({
     db,
@@ -686,6 +709,20 @@ async function main() {
     compilationAgent,
   });
   scheduler.start();
+
+  // v0.5.1: kick off a non-blocking update check at boot so the CoS knows
+  // about pending updates on the first conversation, not 60s after boot.
+  // Inner function self-throttles to 24h via instance_settings TTL.
+  if (process.env.CARSONOS_DISABLE_UPDATE_CHECK !== "1") {
+    void import("./services/system-update-check.js")
+      .then(({ checkForUpdate }) => checkForUpdate(db))
+      .catch((err) =>
+        console.warn(
+          "[update-check] boot check failed:",
+          err instanceof Error ? err.message : String(err),
+        ),
+      );
+  }
 
   // Start listening on loopback only
   server.listen(config.port, "127.0.0.1", () => {

--- a/server/src/services/__tests__/system-update-check.test.ts
+++ b/server/src/services/__tests__/system-update-check.test.ts
@@ -231,3 +231,221 @@ describe("checkForUpdate", () => {
     expect(fetchCount).toBeGreaterThan(firstCount);
   });
 });
+
+// ── compareVersions: NaN-rejecting behavior (review fix) ──────────
+
+describe("compareVersions: rejects non-numeric segments", () => {
+  it("throws on segments that don't parse as numbers", () => {
+    expect(() => compareVersions("0.5.1-beta", "0.5.0")).toThrow(/non-numeric/);
+    expect(() => compareVersions("0.5.0", "0.5.x")).toThrow(/non-numeric/);
+    expect(() => compareVersions("not.a.version", "0.0.0")).toThrow();
+  });
+
+  it("does NOT throw on legitimate dotted-numeric shapes", () => {
+    expect(() => compareVersions("0.5.0", "0.5.1")).not.toThrow();
+    expect(() => compareVersions("0.5", "1.0.0.0")).not.toThrow();
+  });
+});
+
+// ── checkForUpdate: malformed local VERSION survives ──────────────
+
+describe("checkForUpdate: malformed local VERSION", () => {
+  let db: Db;
+  beforeEach(() => {
+    db = createDb(":memory:");
+  });
+
+  it("returns null instead of throwing when local VERSION is malformed", async () => {
+    const fetcher = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/VERSION")) return new Response("0.5.1");
+      return new Response(SAMPLE_CHANGELOG);
+    }) as typeof fetch;
+
+    // Local "0.5.1-beta" would have silently compared as equal under the
+    // old (NaN-tolerant) compareVersions. The new throw-and-catch path
+    // surfaces this as null, not equal-to-remote.
+    const result = await checkForUpdate(db, {
+      currentVersion: "0.5.1-beta",
+      fetcher,
+      force: true,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+// ── apply_system_update trust gate (review fix MEDIUM #6) ─────────
+
+describe("apply_system_update trust gate", () => {
+  let db: Db;
+  let parentMemberId: string;
+  let kidMemberId: string;
+  let householdId: string;
+  let cosAgentId: string;
+  let otherHouseholdMemberId: string;
+
+  beforeEach(async () => {
+    db = createDb(":memory:");
+
+    const { households, familyMembers, staffAgents } = await import("@carsonos/db");
+    const { eq } = await import("drizzle-orm");
+
+    const [household] = await db
+      .insert(households)
+      .values({ name: "Test Household" })
+      .returning();
+    householdId = household.id;
+
+    const [parent] = await db
+      .insert(familyMembers)
+      .values({
+        householdId,
+        name: "Parent",
+        role: "parent",
+        age: 40,
+      })
+      .returning();
+    parentMemberId = parent.id;
+
+    const [kid] = await db
+      .insert(familyMembers)
+      .values({
+        householdId,
+        name: "Kid",
+        role: "child",
+        age: 10,
+      })
+      .returning();
+    kidMemberId = kid.id;
+
+    // Member from a DIFFERENT household, used to test the household
+    // scoping clause on the member lookup (review HIGH #3).
+    const [otherHousehold] = await db
+      .insert(households)
+      .values({ name: "Other Household" })
+      .returning();
+    const [otherParent] = await db
+      .insert(familyMembers)
+      .values({
+        householdId: otherHousehold.id,
+        name: "Other Parent",
+        role: "parent",
+        age: 42,
+      })
+      .returning();
+    otherHouseholdMemberId = otherParent.id;
+
+    const [cos] = await db
+      .insert(staffAgents)
+      .values({
+        householdId,
+        name: "Carson",
+        staffRole: "head_butler",
+        roleContent: "CoS for tests",
+        isHeadButler: true,
+      })
+      .returning();
+    cosAgentId = cos.id;
+
+    // Seed an update_available row so the handler's first check passes.
+    const { writeUpdatePending } = await import("../system-update-check.js");
+    void writeUpdatePending; // silence import-only warning
+    const { instanceSettings } = await import("@carsonos/db");
+    await db.insert(instanceSettings).values({
+      id: crypto.randomUUID(),
+      key: "system.update_available",
+      value: {
+        from: "0.5.0",
+        to: "0.5.1",
+        fetchedAt: new Date().toISOString(),
+        changelogExcerpt: "test changelog",
+      },
+    });
+
+    // Touch eq to satisfy import-only check.
+    void eq;
+  });
+
+  it("refuses when isChiefOfStaff is false (non-CoS agent)", async () => {
+    const { handleAgentTool } = await import("../agent-tools.js");
+    const result = await handleAgentTool(
+      {
+        db,
+        agentId: cosAgentId,
+        memberId: parentMemberId,
+        memberName: "Parent",
+        householdId,
+        isChiefOfStaff: false,
+      },
+      "apply_system_update",
+      {},
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.content).toMatch(/Chief of Staff/i);
+  });
+
+  it("refuses when the requesting member is a kid (role !== 'parent')", async () => {
+    const { handleAgentTool } = await import("../agent-tools.js");
+    const result = await handleAgentTool(
+      {
+        db,
+        agentId: cosAgentId,
+        memberId: kidMemberId,
+        memberName: "Kid",
+        householdId,
+        isChiefOfStaff: true,
+      },
+      "apply_system_update",
+      {},
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.content).toMatch(/parent/i);
+    expect(result.content).toContain("Kid");
+  });
+
+  it("refuses when the memberId resolves to a different household (cross-household auth gap)", async () => {
+    const { handleAgentTool } = await import("../agent-tools.js");
+    // CoS in our household + memberId from the OTHER household. The
+    // member exists in the DB but belongs to a different household.
+    // The household-scoped lookup should return zero rows.
+    const result = await handleAgentTool(
+      {
+        db,
+        agentId: cosAgentId,
+        memberId: otherHouseholdMemberId,
+        memberName: "Other Parent",
+        householdId, // OUR household
+        isChiefOfStaff: true,
+      },
+      "apply_system_update",
+      {},
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.content).toMatch(/resolve the requesting member/i);
+  });
+
+  it("refuses when there is no update available", async () => {
+    // Clear the seeded update_available row so the handler bails early.
+    const { instanceSettings } = await import("@carsonos/db");
+    const { eq } = await import("drizzle-orm");
+    await db
+      .delete(instanceSettings)
+      .where(eq(instanceSettings.key, "system.update_available"));
+
+    const { handleAgentTool } = await import("../agent-tools.js");
+    const result = await handleAgentTool(
+      {
+        db,
+        agentId: cosAgentId,
+        memberId: parentMemberId,
+        memberName: "Parent",
+        householdId,
+        isChiefOfStaff: true,
+      },
+      "apply_system_update",
+      {},
+    );
+    expect(result.is_error).toBe(true);
+    expect(result.content).toMatch(/No CarsonOS update is currently available/i);
+  });
+});

--- a/server/src/services/__tests__/system-update-check.test.ts
+++ b/server/src/services/__tests__/system-update-check.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for the system update self-awareness module (TODO-3).
+ *
+ * Pure-helper coverage: compareVersions, extractChangelogEntry, sanitizeExcerpt.
+ * Integration coverage: checkForUpdate against an injected fake fetcher with
+ * an in-memory SQLite (createDb(":memory:")) so the cache TTL, write/read,
+ * and clear paths are exercised end-to-end without hitting GitHub.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDb, type Db } from "@carsonos/db";
+
+import {
+  checkForUpdate,
+  compareVersions,
+  extractChangelogEntry,
+  sanitizeExcerpt,
+  readUpdateAvailable,
+} from "../system-update-check.js";
+
+// ── compareVersions ───────────────────────────────────────────────
+
+describe("compareVersions", () => {
+  it("orders 4-digit versions correctly", () => {
+    expect(compareVersions("0.5.0", "0.5.1")).toBe(-1);
+    expect(compareVersions("0.5.1", "0.5.0")).toBe(1);
+    expect(compareVersions("0.5.0", "0.5.0")).toBe(0);
+  });
+
+  it("orders mixed 3-digit and 4-digit shapes by zero-padding", () => {
+    // 0.5.0 (3-digit) treated as 0.5.0.0 — strictly less than 0.5.0.1
+    expect(compareVersions("0.5.0", "0.5.0.1")).toBe(-1);
+    expect(compareVersions("0.5.0.0", "0.5.0")).toBe(0);
+  });
+
+  it("handles major-version differences", () => {
+    expect(compareVersions("0.9.99", "1.0.0")).toBe(-1);
+    expect(compareVersions("1.0.0", "0.9.99")).toBe(1);
+  });
+
+  it("treats trailing zeros as equal", () => {
+    expect(compareVersions("0.5.0", "0.5.0.0")).toBe(0);
+    expect(compareVersions("0.5", "0.5.0.0")).toBe(0);
+  });
+});
+
+// ── extractChangelogEntry ─────────────────────────────────────────
+
+const SAMPLE_CHANGELOG = `# Changelog
+
+All notable changes to CarsonOS will be documented in this file.
+
+## [0.5.1] - 2026-05-01
+
+### Added
+
+- The agent now tells you when an update is available.
+- /api/health reports adapter status correctly.
+
+### Why this matters
+
+Closes the loop on the v0.4 → v0.5 manual update pain.
+
+## [0.5.0] - 2026-05-01
+
+### Added — Memory v0.5
+
+- Enrichment worker.
+- Compilation agent.
+
+## [0.4.2.1] - 2026-04-27
+`;
+
+describe("extractChangelogEntry", () => {
+  it("pulls the entry for an existing version", () => {
+    const entry = extractChangelogEntry(SAMPLE_CHANGELOG, "0.5.1");
+    expect(entry).toContain("The agent now tells you");
+    expect(entry).toContain("Closes the loop");
+    // Should NOT include the next entry's content.
+    expect(entry).not.toContain("Memory v0.5");
+    expect(entry).not.toContain("Enrichment worker");
+  });
+
+  it("handles the last entry in the file (no following ## [ marker)", () => {
+    const entry = extractChangelogEntry(SAMPLE_CHANGELOG, "0.4.2.1");
+    expect(entry).toBe(""); // empty body, but still finds the header
+  });
+
+  it("returns empty string when version isn't in the changelog", () => {
+    expect(extractChangelogEntry(SAMPLE_CHANGELOG, "9.9.9.9")).toBe("");
+  });
+
+  it("regex-escapes the version (dots are literal, not 'any char')", () => {
+    // 0.5.1 must not match a hypothetical 0X5X1 (dots-as-anything regex bug).
+    const malicious = "## [0X5X1] - 2026-05-01\n\nWrong entry.";
+    const safe = SAMPLE_CHANGELOG + "\n" + malicious;
+    const entry = extractChangelogEntry(safe, "0.5.1");
+    expect(entry).not.toContain("Wrong entry");
+    expect(entry).toContain("The agent now tells you");
+  });
+});
+
+// ── sanitizeExcerpt ───────────────────────────────────────────────
+
+describe("sanitizeExcerpt", () => {
+  it("strips C0 control bytes (NUL, BEL, ESC, DEL)", () => {
+    const dirty = "ok\x00\x07\x1Btext\x7F";
+    expect(sanitizeExcerpt(dirty)).toBe("oktext");
+  });
+
+  it("preserves legitimate whitespace (tab, newline, carriage return)", () => {
+    expect(sanitizeExcerpt("line1\nline2\trow\rend")).toBe("line1\nline2\trow\rend");
+  });
+
+  it("caps oversized payloads with a truncation marker", () => {
+    const huge = "X".repeat(5000);
+    const out = sanitizeExcerpt(huge);
+    expect(out.length).toBeLessThanOrEqual(1500);
+    expect(out).toMatch(/\[truncated to \d+B\]/);
+  });
+
+  it("leaves under-cap payloads untouched", () => {
+    const small = "A short changelog excerpt.";
+    expect(sanitizeExcerpt(small)).toBe(small);
+  });
+});
+
+// ── checkForUpdate (integration with in-memory DB + fake fetcher) ──
+
+describe("checkForUpdate", () => {
+  let db: Db;
+
+  beforeEach(() => {
+    db = createDb(":memory:");
+  });
+
+  function makeFetcher(version: string, changelog: string) {
+    return (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/VERSION")) {
+        return new Response(version);
+      }
+      if (url.endsWith("/CHANGELOG.md")) {
+        return new Response(changelog);
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+  }
+
+  it("writes update_available when remote > local", async () => {
+    const result = await checkForUpdate(db, {
+      currentVersion: "0.5.0",
+      fetcher: makeFetcher("0.5.1", SAMPLE_CHANGELOG),
+      force: true,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.from).toBe("0.5.0");
+    expect(result!.to).toBe("0.5.1");
+    expect(result!.changelogExcerpt).toContain("The agent now tells you");
+
+    // Persisted to instance_settings.
+    const stored = await readUpdateAvailable(db);
+    expect(stored?.to).toBe("0.5.1");
+  });
+
+  it("returns null and clears stale state when local >= remote", async () => {
+    // First run: remote ahead, state gets written.
+    await checkForUpdate(db, {
+      currentVersion: "0.5.0",
+      fetcher: makeFetcher("0.5.1", SAMPLE_CHANGELOG),
+      force: true,
+    });
+    expect(await readUpdateAvailable(db)).not.toBeNull();
+
+    // Second run: we caught up. State should be cleared.
+    const result = await checkForUpdate(db, {
+      currentVersion: "0.5.1",
+      fetcher: makeFetcher("0.5.1", SAMPLE_CHANGELOG),
+      force: true,
+    });
+    expect(result).toBeNull();
+    expect(await readUpdateAvailable(db)).toBeNull();
+  });
+
+  it("rejects malformed remote VERSION", async () => {
+    const result = await checkForUpdate(db, {
+      currentVersion: "0.5.0",
+      fetcher: makeFetcher("not-a-version\n<html>broken</html>", SAMPLE_CHANGELOG),
+      force: true,
+    });
+    expect(result).toBeNull();
+    expect(await readUpdateAvailable(db)).toBeNull();
+  });
+
+  it("survives fetch failures (returns null, no throw)", async () => {
+    const failingFetch = (async () => {
+      throw new Error("ENETUNREACH");
+    }) as typeof fetch;
+    const result = await checkForUpdate(db, {
+      currentVersion: "0.5.0",
+      fetcher: failingFetch,
+      force: true,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("respects the 24h cache (no second fetch within window)", async () => {
+    let fetchCount = 0;
+    const countingFetch = (async (input: RequestInfo | URL) => {
+      fetchCount += 1;
+      const url = String(input);
+      if (url.endsWith("/VERSION")) return new Response("0.5.1");
+      return new Response(SAMPLE_CHANGELOG);
+    }) as typeof fetch;
+
+    // First call hits the network (force not set, no cache yet).
+    await checkForUpdate(db, { currentVersion: "0.5.0", fetcher: countingFetch });
+    const firstCount = fetchCount;
+    expect(firstCount).toBeGreaterThan(0);
+
+    // Second call within the 24h window hits the cache — no new fetches.
+    await checkForUpdate(db, { currentVersion: "0.5.0", fetcher: countingFetch });
+    expect(fetchCount).toBe(firstCount);
+
+    // force=true bypasses the cache.
+    await checkForUpdate(db, {
+      currentVersion: "0.5.0",
+      fetcher: countingFetch,
+      force: true,
+    });
+    expect(fetchCount).toBeGreaterThan(firstCount);
+  });
+});

--- a/server/src/services/agent-tools.ts
+++ b/server/src/services/agent-tools.ts
@@ -198,7 +198,22 @@ export const STAFF_TOOLS: ToolDefinition[] = [
   },
 ];
 
-export const AGENT_TOOLS: ToolDefinition[] = [...SELF_TOOLS, ...STAFF_TOOLS];
+/**
+ * System-level tools — touch the host process (e.g., restart for an update).
+ * Stricter trust gate than STAFF_TOOLS: requires CoS AND a parent-role member.
+ * A kid asking the CoS to update CarsonOS gets politely refused; a parent
+ * asking gets the actual restart.
+ */
+export const SYSTEM_TOOLS: ToolDefinition[] = [
+  {
+    name: "apply_system_update",
+    description:
+      "Apply the available CarsonOS update. Pulls main, installs dependencies, and restarts the family runtime. The host will go offline briefly during the restart; the family will see bots stop responding for ~30-60 seconds. Only call this when a parent has explicitly asked you to apply the update — kids cannot trigger it (the tool will refuse). Returns immediately with 'restart in progress'; the actual restart happens in a detached subprocess. After the restart you'll come back up and tell the family what changed (the boot path queues that announcement automatically).",
+    input_schema: { type: "object", properties: {}, required: [] },
+  },
+];
+
+export const AGENT_TOOLS: ToolDefinition[] = [...SELF_TOOLS, ...STAFF_TOOLS, ...SYSTEM_TOOLS];
 
 // ── Handler ───────────────────────────────────────────────────────
 
@@ -211,6 +226,35 @@ export async function handleAgentTool(
   const staffToolNames = STAFF_TOOLS.map((t) => t.name);
   if (staffToolNames.includes(name) && !ctx.isChiefOfStaff) {
     return { content: "Only the Chief of Staff can manage other agents.", is_error: true };
+  }
+
+  // Gate system tools (apply_system_update) to CoS + parent-role member.
+  // A kid chatting with Carson can't trigger the family runtime to restart;
+  // they get a polite "ask a parent" refusal. The member-role lookup is
+  // cheap and the refusal message tells the agent how to proceed.
+  const systemToolNames = SYSTEM_TOOLS.map((t) => t.name);
+  if (systemToolNames.includes(name)) {
+    if (!ctx.isChiefOfStaff) {
+      return {
+        content:
+          "apply_system_update is only available to the Chief of Staff. Personal agents can ask CoS to apply the update on their member's behalf, but only if a parent is asking.",
+        is_error: true,
+      };
+    }
+    const [member] = await ctx.db
+      .select({ role: familyMembers.role, name: familyMembers.name })
+      .from(familyMembers)
+      .where(eq(familyMembers.id, ctx.memberId))
+      .limit(1);
+    if (!member) {
+      return { content: "Could not resolve the requesting member.", is_error: true };
+    }
+    if (member.role !== "parent") {
+      return {
+        content: `${member.name} is a ${member.role}, not a parent. Updates can only be applied at a parent's request — politely tell them to ask a parent instead.`,
+        is_error: true,
+      };
+    }
   }
 
   switch (name) {
@@ -226,8 +270,81 @@ export async function handleAgentTool(
     case "list_agent_tools": return handleListAgentTools(ctx, input);
     case "grant_tool_to_agent": return handleGrantToolToAgent(ctx, input);
     case "revoke_tool_from_agent": return handleRevokeToolFromAgent(ctx, input);
+    case "apply_system_update": return handleApplySystemUpdate(ctx);
     default: return { content: `Unknown agent tool: ${name}`, is_error: true };
   }
+}
+
+// ── apply_system_update handler ────────────────────────────────────
+
+/**
+ * Apply the pending CarsonOS update by writing a `update_pending` state
+ * row and spawning `./scripts/update-service.sh` as a detached subprocess.
+ *
+ * The detached spawn matters: the script will eventually run
+ * `launchctl bootstrap` to restart `com.carsonos.server`, which kills THIS
+ * process. By detaching with `stdio: 'ignore'` we ensure the script
+ * survives the parent exit and completes the restart.
+ *
+ * The handler returns immediately with "restart in progress" so the
+ * agent has a final response to give the user before their session dies.
+ * The post-restart announcement (TODO-3.5) is what closes the loop in
+ * voice on the new instance.
+ */
+async function handleApplySystemUpdate(ctx: AgentToolContext): Promise<ToolResult> {
+  // Resolve which update we're applying. Read the live state — don't
+  // trust the agent's prompt-bound copy of from/to, which could be stale
+  // if the user reshipped between the CoS reading the prompt and calling
+  // the tool.
+  const { readUpdateAvailable, writeUpdatePending } = await import(
+    "./system-update-check.js"
+  );
+  const available = await readUpdateAvailable(ctx.db);
+  if (!available) {
+    return {
+      content:
+        "No CarsonOS update is currently available. The update-check may not have run yet, or the system is already current. Try again later or ask the user if there's an update they're expecting.",
+      is_error: true,
+    };
+  }
+
+  await writeUpdatePending(ctx.db, {
+    from: available.from,
+    to: available.to,
+    changelogExcerpt: available.changelogExcerpt,
+    requestedAt: new Date().toISOString(),
+    householdId: ctx.householdId,
+    requestedByMemberId: ctx.memberId,
+  });
+
+  // Locate the script. Resolve from the running server's __dirname so
+  // we work both in tsx-watch (running from server/src/) and after a
+  // tsc build (running from server/dist/). The script lives at the repo
+  // root: server/src/services/.. → repo root.
+  const { spawn } = await import("node:child_process");
+  const { join } = await import("node:path");
+  const scriptPath = join(import.meta.dirname, "..", "..", "..", "scripts", "update-service.sh");
+
+  try {
+    const child = spawn(scriptPath, [], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+  } catch (err) {
+    return {
+      content: `Failed to spawn update script: ${err instanceof Error ? err.message : String(err)}. The update_pending state has been written but the restart didn't kick off — investigate the script path.`,
+      is_error: true,
+    };
+  }
+
+  console.log(
+    `[apply-update] kicked off update v${available.from} → v${available.to} (requested by member ${ctx.memberId})`,
+  );
+
+  return {
+    content: `Restart in progress. Pulling main, installing dependencies, and restarting com.carsonos.server. Tell ${ctx.memberName} the family runtime will be offline briefly (about 30-60 seconds) while it updates from v${available.from} to v${available.to}, then comes back up. After the restart, you'll automatically tell them what changed.`,
+  };
 }
 
 // ── Self-management handlers ──────────────────────────────────────

--- a/server/src/services/agent-tools.ts
+++ b/server/src/services/agent-tools.ts
@@ -241,10 +241,17 @@ export async function handleAgentTool(
         is_error: true,
       };
     }
+    // Scope the lookup with householdId — defense-in-depth so a CoS in
+    // household A can never authorize an update on behalf of a member from
+    // household B even if memberId somehow gets crossed. Single-family
+    // CarsonOS rarely sees this race, but the guard is one extra clause.
     const [member] = await ctx.db
       .select({ role: familyMembers.role, name: familyMembers.name })
       .from(familyMembers)
-      .where(eq(familyMembers.id, ctx.memberId))
+      .where(and(
+        eq(familyMembers.id, ctx.memberId),
+        eq(familyMembers.householdId, ctx.householdId),
+      ))
       .limit(1);
     if (!member) {
       return { content: "Could not resolve the requesting member.", is_error: true };
@@ -308,42 +315,77 @@ async function handleApplySystemUpdate(ctx: AgentToolContext): Promise<ToolResul
     };
   }
 
-  await writeUpdatePending(ctx.db, {
-    from: available.from,
-    to: available.to,
-    changelogExcerpt: available.changelogExcerpt,
-    requestedAt: new Date().toISOString(),
-    householdId: ctx.householdId,
-    requestedByMemberId: ctx.memberId,
-  });
-
   // Locate the script. Resolve from the running server's __dirname so
   // we work both in tsx-watch (running from server/src/) and after a
   // tsc build (running from server/dist/). The script lives at the repo
   // root: server/src/services/.. → repo root.
   const { spawn } = await import("node:child_process");
   const { join } = await import("node:path");
+  const fs = await import("node:fs");
+  const os = await import("node:os");
   const scriptPath = join(import.meta.dirname, "..", "..", "..", "scripts", "update-service.sh");
 
+  // Capture the script's stdout + stderr to a timestamped log so partial
+  // failures (git pull error, pnpm install error, launchctl kickstart
+  // error) leave a forensic trail. Without this redirect the script
+  // ran with stdio:'ignore' and no logs landed anywhere — debugging
+  // a half-applied update would require re-running the script by hand.
+  const logDir = join(os.homedir(), ".carsonos", "logs");
+  fs.mkdirSync(logDir, { recursive: true });
+  const tsForFile = new Date().toISOString().replace(/[:.]/g, "-");
+  const logPath = join(logDir, `update-${tsForFile}.log`);
+
+  // Spawn FIRST. Only after the OS confirms the child started do we
+  // write update_pending — otherwise a missing/EACCES script would
+  // leave a poison row in instance_settings that makes the next CoS
+  // turn re-propose the update against a system that won't apply it.
+  let child: ReturnType<typeof spawn>;
   try {
-    const child = spawn(scriptPath, [], {
+    const logFd = fs.openSync(logPath, "a");
+    child = spawn(scriptPath, [], {
       detached: true,
-      stdio: "ignore",
+      stdio: ["ignore", logFd, logFd],
     });
     child.unref();
+    // The fd is now owned by the spawned child via dup2 inside spawn —
+    // close our reference so the parent doesn't keep it open.
+    fs.closeSync(logFd);
   } catch (err) {
     return {
-      content: `Failed to spawn update script: ${err instanceof Error ? err.message : String(err)}. The update_pending state has been written but the restart didn't kick off — investigate the script path.`,
+      content: `Failed to spawn update script: ${err instanceof Error ? err.message : String(err)}. No update was triggered. Verify ${scriptPath} exists and is executable.`,
       is_error: true,
     };
   }
 
+  // Spawn succeeded (the OS reported a pid). Now persist update_pending
+  // so the post-restart announcement can fire. If this DB write fails,
+  // the update will still apply but the new instance won't know to
+  // announce it — log loudly so the operator can investigate.
+  try {
+    await writeUpdatePending(ctx.db, {
+      from: available.from,
+      to: available.to,
+      changelogExcerpt: available.changelogExcerpt,
+      requestedAt: new Date().toISOString(),
+      householdId: ctx.householdId,
+      requestedByMemberId: ctx.memberId,
+    });
+  } catch (err) {
+    console.error(
+      `[apply-update] CRITICAL: spawn succeeded but writeUpdatePending failed:`,
+      err,
+      `— the restart will proceed but the post-restart announcement will not fire.`,
+    );
+    // Don't abort — the update IS in flight, the user just won't get
+    // the in-voice announcement on the new instance.
+  }
+
   console.log(
-    `[apply-update] kicked off update v${available.from} → v${available.to} (requested by member ${ctx.memberId})`,
+    `[apply-update] kicked off update v${available.from} → v${available.to} (requested by member ${ctx.memberId}) — pid ${child.pid}, log ${logPath}`,
   );
 
   return {
-    content: `Restart in progress. Pulling main, installing dependencies, and restarting com.carsonos.server. Tell ${ctx.memberName} the family runtime will be offline briefly (about 30-60 seconds) while it updates from v${available.from} to v${available.to}, then comes back up. After the restart, you'll automatically tell them what changed.`,
+    content: `Restart in progress. Pulling main, installing dependencies, and restarting com.carsonos.server. Tell ${ctx.memberName} the family runtime will be offline briefly (about 30-60 seconds) while it updates from v${available.from} to v${available.to}, then comes back up. After the restart, you'll automatically tell them what changed. (Script log: ${logPath})`,
   };
 }
 

--- a/server/src/services/constitution-engine.ts
+++ b/server/src/services/constitution-engine.ts
@@ -44,6 +44,7 @@ import {
   type EvaluationResult,
 } from "./evaluators.js";
 import { compileSystemPrompt } from "./prompt-compiler.js";
+import { readUpdateAvailable } from "./system-update-check.js";
 import { loadUserMd, loadPersonalityMd, slugifyName } from "./identity-files.js";
 import { activityLog, toolSecrets } from "@carsonos/db";
 import { decryptSecret, redactSecrets } from "./custom-tools/secrets.js";
@@ -605,6 +606,24 @@ export class ConstitutionEngine {
     const userMdContent = this.dataDir ? loadUserMd(this.dataDir, memberSlug) : null;
     const personalityMdContent = this.dataDir ? loadPersonalityMd(this.dataDir, agentSlug) : null;
 
+    // Chief-of-Staff-only sections. Determined here so we can decide
+    // whether to fetch the (DB-backed) update-available state — personal
+    // agents and specialists never see it.
+    const isCoSForPrompt = agent.isHeadButler || agent.staffRole === "head_butler";
+    let updateAvailable = null as Awaited<ReturnType<typeof readUpdateAvailable>>;
+    if (isCoSForPrompt) {
+      try {
+        updateAvailable = await readUpdateAvailable(this.db);
+      } catch (err) {
+        // Don't block a turn on instance_settings read errors. CoS just
+        // won't surface the update on this turn; next turn retries.
+        console.warn(
+          "[constitution-engine] readUpdateAvailable failed:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+
     const systemPrompt = compileSystemPrompt({
       mode: "chat",
       roleContent: agent.roleContent ?? "",
@@ -625,6 +644,13 @@ export class ConstitutionEngine {
       enabledSkills: enabledSkills ?? null,
       householdName: household?.name ?? null,
       householdMembers: allMembers ?? null,
+      updateAvailable: updateAvailable
+        ? {
+            from: updateAvailable.from,
+            to: updateAvailable.to,
+            changelogExcerpt: updateAvailable.changelogExcerpt,
+          }
+        : null,
     });
     perf.promptMs = Date.now() - promptStart;
 

--- a/server/src/services/prompt-compiler.ts
+++ b/server/src/services/prompt-compiler.ts
@@ -41,6 +41,14 @@ export interface CompilePromptParams {
   // Household roster (all family members)
   householdName?: string | null;
   householdMembers?: Array<{ name: string; role: string; age: number }> | null;
+  /** Pending CarsonOS update for the Chief of Staff to surface (TODO-3).
+   * Constitution-engine reads from instance_settings and passes this only
+   * to head_butler agents — personal agents never see it. */
+  updateAvailable?: {
+    from: string;
+    to: string;
+    changelogExcerpt: string;
+  } | null;
 }
 
 export interface DelegationEdge {
@@ -319,6 +327,39 @@ function compileChatPrompt(params: CompilePromptParams): string {
   // 10. Delegation instructions (personal agents only)
   if (delegationInstructions) {
     sections.push(`# Delegation\n\n${delegationInstructions}`);
+  }
+
+  // 11. CarsonOS update available — Chief of Staff only. constitution-engine
+  // gates this so personal agents and specialists never see the section.
+  // The excerpt has already been sanitized (control chars stripped, length
+  // capped) by services/system-update-check.ts before reaching here.
+  if (params.updateAvailable) {
+    const { from, to, changelogExcerpt } = params.updateAvailable;
+    sections.push(
+      [
+        "# CarsonOS Update Available",
+        "",
+        `The system you run on is at v${from}. Latest is v${to}.`,
+        "",
+        "If it fits the conversation, mention this casually to the user (don't",
+        "lead with it — drop it in if there's a natural opening). When you do,",
+        "summarize the changelog excerpt below in plain English: what they'll",
+        "be able to do that they can't now.",
+        "",
+        "Only a parent (full-trust member) can apply the update. If a parent",
+        "asks you to apply it, call `apply_system_update` — that script will",
+        "git pull main, install dependencies, and restart the service. The host",
+        "will go offline briefly during the restart; that's expected. After",
+        "the restart, you'll come back up and tell the family what changed.",
+        "",
+        "If a kid asks for the update, politely tell them to ask a parent —",
+        "the tool won't let you run it on a non-parent's behalf.",
+        "",
+        "## Changelog excerpt (vX → vY)",
+        "",
+        changelogExcerpt || "(no changelog excerpt available — describe v" + to + " generically)",
+      ].join("\n"),
+    );
   }
 
   return sections.join("\n\n");

--- a/server/src/services/prompt-compiler.ts
+++ b/server/src/services/prompt-compiler.ts
@@ -355,7 +355,7 @@ function compileChatPrompt(params: CompilePromptParams): string {
         "If a kid asks for the update, politely tell them to ask a parent —",
         "the tool won't let you run it on a non-parent's behalf.",
         "",
-        "## Changelog excerpt (vX → vY)",
+        `## Changelog excerpt (v${from} → v${to})`,
         "",
         changelogExcerpt || "(no changelog excerpt available — describe v" + to + " generically)",
       ].join("\n"),

--- a/server/src/services/scheduler.ts
+++ b/server/src/services/scheduler.ts
@@ -254,6 +254,19 @@ export class Scheduler {
           console.warn("[compilation-agent] tick error:", err);
         }
       }
+
+      // v0.5.1: system update self-awareness. Cheap when cached (one DB
+      // read per tick); the actual GitHub fetch only fires every 24h via
+      // the function's internal TTL gate. Disabled via env for tests
+      // and air-gapped deploys.
+      if (process.env.CARSONOS_DISABLE_UPDATE_CHECK !== "1") {
+        try {
+          const { checkForUpdate } = await import("./system-update-check.js");
+          await checkForUpdate(this.db);
+        } catch (err) {
+          console.warn("[update-check] tick error:", err);
+        }
+      }
     } catch (err) {
       console.error("[scheduler] Tick error:", err);
     } finally {

--- a/server/src/services/system-update-check.ts
+++ b/server/src/services/system-update-check.ts
@@ -133,7 +133,17 @@ export async function checkForUpdate(
   // gate works even when we're up-to-date.
   await writeSetting(db, KEY_LAST_CHECKED, { at: new Date().toISOString() });
 
-  if (compareVersions(remoteVersion, localVersion) <= 0) {
+  let cmp: number;
+  try {
+    cmp = compareVersions(remoteVersion, localVersion);
+  } catch (err) {
+    console.warn(
+      "[update-check] cannot compare versions:",
+      err instanceof Error ? err.message : String(err),
+    );
+    return null;
+  }
+  if (cmp <= 0) {
     // We're current or ahead. Clear any stale "available" row so the
     // CoS prompt doesn't keep proposing an update that's already shipped.
     await deleteSetting(db, KEY_UPDATE_AVAILABLE);
@@ -224,9 +234,33 @@ export async function announceUpdateApplied(
     return;
   }
 
-  if (compareVersions(current, pending.to) < 0) {
+  let cmp: number;
+  try {
+    cmp = compareVersions(current, pending.to);
+  } catch (err) {
+    console.warn(
+      "[update-check] post-restart: cannot compare versions, skipping announcement:",
+      err instanceof Error ? err.message : String(err),
+    );
+    // Don't clear pending — the next boot may have a sane VERSION.
+    return;
+  }
+  if (cmp < 0) {
     console.warn(
       `[update-check] post-restart: requested v${pending.to} but running v${current}; update appears to have failed. Clearing pending row.`,
+    );
+    await clearUpdatePending(db);
+    return;
+  }
+  if (cmp > 0) {
+    // We're AHEAD of pending.to — someone pulled a newer version manually
+    // (outside the apply_system_update path) before the post-restart
+    // announcement could fire. The cached changelog excerpt is for the
+    // version we PASSED, not the version we landed on. Don't announce
+    // with stale content; clear the row and let checkForUpdate decide
+    // what to surface next.
+    console.warn(
+      `[update-check] post-restart: running v${current} ahead of pending.to v${pending.to}; clearing stale pending row without announcing (user pulled newer manually).`,
     );
     await clearUpdatePending(db);
     return;
@@ -337,10 +371,22 @@ export async function announceUpdateApplied(
 /**
  * Compare two CarsonOS versions. Returns -1 if a < b, 0 if equal, 1 if a > b.
  * Handles both 3-digit (legacy) and 4-digit shapes by zero-padding.
+ *
+ * Throws when either input has a non-numeric segment (e.g. "0.5.1-beta",
+ * "0.5.x"). NaN comparisons silently return false, which would have made
+ * compareVersions return 0 (equal) for any pair containing a NaN — and a
+ * stale-but-equal pending row could fire the post-restart announcement
+ * with the wrong content. Callers handle the throw via try/catch and
+ * treat it as "can't compare → don't announce / don't claim out-of-date."
  */
 export function compareVersions(a: string, b: string): -1 | 0 | 1 {
   const pa = a.split(".").map(Number);
   const pb = b.split(".").map(Number);
+  if (pa.some(Number.isNaN) || pb.some(Number.isNaN)) {
+    throw new Error(
+      `compareVersions: non-numeric segment in '${a}' vs '${b}'; refusing to silently treat as equal`,
+    );
+  }
   const max = Math.max(pa.length, pb.length);
   for (let i = 0; i < max; i++) {
     const ai = pa[i] ?? 0;

--- a/server/src/services/system-update-check.ts
+++ b/server/src/services/system-update-check.ts
@@ -1,0 +1,475 @@
+/**
+ * System update self-awareness.
+ *
+ * Compares the local CarsonOS VERSION against the latest version on
+ * `origin/main` (raw GitHub fetch — no git side effects, no auth) and
+ * writes the result to `instance_settings` so the Chief of Staff can
+ * surface pending updates in-voice on the next interaction.
+ *
+ * Key state rows:
+ *   - `system.update_available` — { from, to, fetchedAt, changelogExcerpt }
+ *     written when remote > local. Read by the CoS prompt assembler.
+ *   - `system.update_pending`   — { from, to, changelogExcerpt, requestedAt }
+ *     written by the `apply_system_update` tool RIGHT BEFORE the host
+ *     restarts. Read on next boot to drive the in-voice "update applied"
+ *     announcement (TODO-3.5).
+ *
+ * Daily TTL: a successful check sets `last_checked_at`. Subsequent calls
+ * within 24h are no-ops unless `force: true` is passed.
+ *
+ * Failure modes (offline, GitHub 404, malformed VERSION) are caught,
+ * logged once, and do not throw — boot/scheduler ticks must not be
+ * blocked by transient network errors.
+ *
+ * The changelog excerpt is a trust-boundary surface: anyone who can edit
+ * CHANGELOG.md can inject prompt content. Sanitization (control chars
+ * stripped, length capped) lives here.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+import type { Db } from "@carsonos/db";
+import { instanceSettings } from "@carsonos/db";
+
+// ── Constants ──────────────────────────────────────────────────────
+
+const REPO_OWNER = "joshdaws";
+const REPO_NAME = "carson-os";
+const VERSION_URL = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/main/VERSION`;
+const CHANGELOG_URL = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/main/CHANGELOG.md`;
+
+const FETCH_TIMEOUT_MS = 5_000;
+const CHECK_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const EXCERPT_MAX_BYTES = 1500;
+const VERSION_REGEX = /^\d+\.\d+\.\d+(?:\.\d+)?$/;
+
+const KEY_UPDATE_AVAILABLE = "system.update_available";
+const KEY_LAST_CHECKED = "system.update_check.last_checked_at";
+export const KEY_UPDATE_PENDING = "system.update_pending";
+
+// ── Public API ─────────────────────────────────────────────────────
+
+export interface UpdateAvailable {
+  from: string;
+  to: string;
+  fetchedAt: string; // ISO 8601
+  changelogExcerpt: string;
+}
+
+export interface UpdatePending {
+  from: string;
+  to: string;
+  changelogExcerpt: string;
+  requestedAt: string; // ISO 8601
+  /** Household whose CoS will deliver the post-restart announcement. */
+  householdId: string;
+  /** Member who requested the update; the post-restart message is sent to them. */
+  requestedByMemberId: string;
+}
+
+export interface CheckOptions {
+  /** When true, ignores the 24h cache and forces a fresh fetch. */
+  force?: boolean;
+  /** Override the local version (test-only). Defaults to reading VERSION file. */
+  currentVersion?: string;
+  /** Override the fetcher (test-only). Defaults to global fetch. */
+  fetcher?: typeof fetch;
+}
+
+/**
+ * Run an update check. Idempotent and bounded — safe to call from boot
+ * and from the scheduler tick. Returns the resulting UpdateAvailable
+ * record (when one exists), or null if up-to-date / errored / cached.
+ */
+export async function checkForUpdate(
+  db: Db,
+  options: CheckOptions = {},
+): Promise<UpdateAvailable | null> {
+  // Cache gate: skip the network call if we ran in the last 24h, unless
+  // the caller forces a fresh check.
+  if (!options.force) {
+    const last = await readSetting(db, KEY_LAST_CHECKED);
+    if (last && typeof last === "object" && "at" in last) {
+      const lastAt = new Date((last as { at: string }).at).getTime();
+      if (Number.isFinite(lastAt) && Date.now() - lastAt < CHECK_TTL_MS) {
+        // Cache hit. Return the previously-recorded available state if any.
+        const cached = await readSetting(db, KEY_UPDATE_AVAILABLE);
+        return isUpdateAvailable(cached) ? cached : null;
+      }
+    }
+  }
+
+  const localVersion = options.currentVersion ?? readLocalVersion();
+  if (!localVersion) {
+    console.warn("[update-check] could not read local VERSION; skipping");
+    return null;
+  }
+
+  let remoteVersion: string;
+  let remoteChangelog: string;
+  try {
+    [remoteVersion, remoteChangelog] = await Promise.all([
+      fetchText(VERSION_URL, options.fetcher),
+      fetchText(CHANGELOG_URL, options.fetcher),
+    ]);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn("[update-check] fetch failed:", msg);
+    // Don't update last-checked timestamp on transient network errors;
+    // we want the next tick to retry instead of waiting 24h.
+    return null;
+  }
+
+  remoteVersion = remoteVersion.trim();
+  if (!VERSION_REGEX.test(remoteVersion)) {
+    console.warn(
+      `[update-check] remote VERSION malformed: ${JSON.stringify(remoteVersion).slice(0, 80)}; skipping`,
+    );
+    return null;
+  }
+
+  // Mark the check as done regardless of comparison result so the cache
+  // gate works even when we're up-to-date.
+  await writeSetting(db, KEY_LAST_CHECKED, { at: new Date().toISOString() });
+
+  if (compareVersions(remoteVersion, localVersion) <= 0) {
+    // We're current or ahead. Clear any stale "available" row so the
+    // CoS prompt doesn't keep proposing an update that's already shipped.
+    await deleteSetting(db, KEY_UPDATE_AVAILABLE);
+    return null;
+  }
+
+  const excerpt = sanitizeExcerpt(extractChangelogEntry(remoteChangelog, remoteVersion));
+  const update: UpdateAvailable = {
+    from: localVersion,
+    to: remoteVersion,
+    fetchedAt: new Date().toISOString(),
+    changelogExcerpt: excerpt,
+  };
+  await writeSetting(db, KEY_UPDATE_AVAILABLE, update);
+  return update;
+}
+
+/** Read the current `update_available` row, or null. */
+export async function readUpdateAvailable(db: Db): Promise<UpdateAvailable | null> {
+  const v = await readSetting(db, KEY_UPDATE_AVAILABLE);
+  return isUpdateAvailable(v) ? v : null;
+}
+
+/** Read the `update_pending` row written before a restart, or null. */
+export async function readUpdatePending(db: Db): Promise<UpdatePending | null> {
+  const v = await readSetting(db, KEY_UPDATE_PENDING);
+  return isUpdatePending(v) ? v : null;
+}
+
+/** Write the `update_pending` row. Called by `apply_system_update` right before spawn. */
+export async function writeUpdatePending(db: Db, value: UpdatePending): Promise<void> {
+  await writeSetting(db, KEY_UPDATE_PENDING, value);
+}
+
+/** Clear the `update_pending` row after the post-restart announcement runs. */
+export async function clearUpdatePending(db: Db): Promise<void> {
+  await deleteSetting(db, KEY_UPDATE_PENDING);
+}
+
+// ── Post-restart announcement (TODO-3.5) ──────────────────────────
+
+/**
+ * Inputs the boot path must inject. Mirrors the wakeDelegator wiring in
+ * delegation-service.ts: the engine runs an in-voice turn for the CoS,
+ * and the sender delivers the result via the matching telegram bot.
+ */
+export interface AnnounceUpdateAppliedDeps {
+  /** ConstitutionEngine.processMessage, narrowed. */
+  processMessage: (input: {
+    agentId: string;
+    memberId: string;
+    householdId: string;
+    message: string;
+    channel: "telegram" | "web";
+  }) => Promise<{ blocked?: boolean; response?: string }>;
+  /** multiRelay.sendMessage(agentId, telegramUserId, text). */
+  sendToUser: (
+    agentId: string,
+    telegramUserId: string,
+    text: string,
+  ) => Promise<unknown>;
+  /** Read the version baked into the running process. Lets tests stub. */
+  currentVersion?: string;
+}
+
+/**
+ * Run once on boot, AFTER multiRelay is up. If the previous instance
+ * wrote an `update_pending` row before restarting AND we came back up
+ * at the expected version, queue a one-shot in-voice announcement from
+ * the household's Chief of Staff to the requesting member.
+ *
+ * If the boot's VERSION is below the requested `to` (the update didn't
+ * actually apply, or rolled back), log a warning and clear the pending
+ * row so we don't keep trying.
+ */
+export async function announceUpdateApplied(
+  db: Db,
+  deps: AnnounceUpdateAppliedDeps,
+): Promise<void> {
+  const pending = await readUpdatePending(db);
+  if (!pending) return;
+
+  const current = deps.currentVersion ?? readLocalVersion();
+  if (!current) {
+    console.warn(
+      "[update-check] post-restart: cannot read local VERSION, skipping announcement",
+    );
+    return;
+  }
+
+  if (compareVersions(current, pending.to) < 0) {
+    console.warn(
+      `[update-check] post-restart: requested v${pending.to} but running v${current}; update appears to have failed. Clearing pending row.`,
+    );
+    await clearUpdatePending(db);
+    return;
+  }
+
+  // Look up the household's CoS and the requesting member's telegram id.
+  // Local imports kept here so the static import surface of system-update-
+  // check.ts stays minimal.
+  const { staffAgents, familyMembers } = await import("@carsonos/db");
+  const { eq, and } = await import("drizzle-orm");
+
+  const [cos] = await db
+    .select({ id: staffAgents.id })
+    .from(staffAgents)
+    .where(
+      and(
+        eq(staffAgents.householdId, pending.householdId),
+        eq(staffAgents.staffRole, "head_butler"),
+      ),
+    )
+    .limit(1);
+  if (!cos) {
+    console.warn(
+      `[update-check] post-restart: no head_butler agent for household ${pending.householdId}; skipping announcement`,
+    );
+    await clearUpdatePending(db);
+    return;
+  }
+
+  const [member] = await db
+    .select({
+      id: familyMembers.id,
+      name: familyMembers.name,
+      telegramUserId: familyMembers.telegramUserId,
+    })
+    .from(familyMembers)
+    .where(eq(familyMembers.id, pending.requestedByMemberId))
+    .limit(1);
+  if (!member) {
+    console.warn(
+      `[update-check] post-restart: requesting member ${pending.requestedByMemberId} not found; skipping announcement`,
+    );
+    await clearUpdatePending(db);
+    return;
+  }
+  if (!member.telegramUserId) {
+    console.warn(
+      `[update-check] post-restart: ${member.name} has no telegram_user_id; skipping announcement`,
+    );
+    await clearUpdatePending(db);
+    return;
+  }
+
+  // Build a plain-prose system trigger. The trigger format mirrors
+  // wakeDelegator's pattern: tagged key:value lines, no sentinel format,
+  // and a closing instruction telling the agent NOT to echo the trigger.
+  const trigger = [
+    "System update applied: the CarsonOS update you proposed has finished installing and the host is back up.",
+    `- from: v${pending.from}`,
+    `- to: v${current}`,
+    `- requested by: ${member.name}`,
+    "",
+    "Tell the user — in your own voice, briefly — that the update is done and what changed. Use the changelog excerpt below to pick out 1-3 user-facing wins worth mentioning. Keep it short, conversational, and don't restate the version numbers in raw form (say 'the latest update' or 'the v0.5.1 release', not 'vN.M.K applied').",
+    "",
+    "Do not restate this trigger back to the user. Do not list every changelog bullet — pick the 1-3 most relevant.",
+    "",
+    "## Changelog excerpt",
+    "",
+    pending.changelogExcerpt || "(no changelog excerpt available — describe v" + pending.to + " generically)",
+  ].join("\n");
+
+  try {
+    const result = await deps.processMessage({
+      agentId: cos.id,
+      memberId: member.id,
+      householdId: pending.householdId,
+      message: trigger,
+      channel: "telegram",
+    });
+    if (result.blocked) {
+      console.warn("[update-check] post-restart: engine blocked the announcement turn");
+      // Don't clear pending — we'll retry on next boot in case this was
+      // a transient block. If the user reboots without using the app, the
+      // announcement will fire then.
+      return;
+    }
+    const text = result.response?.trim();
+    if (!text) {
+      console.warn("[update-check] post-restart: engine returned empty response");
+      return;
+    }
+    await deps.sendToUser(cos.id, member.telegramUserId, text);
+    await clearUpdatePending(db);
+    console.log(
+      `[update-check] post-restart announcement delivered to ${member.name} (v${pending.from} → v${current})`,
+    );
+  } catch (err) {
+    console.warn(
+      "[update-check] post-restart announcement failed:",
+      err instanceof Error ? err.message : String(err),
+    );
+    // Leave pending in place; next boot will retry.
+  }
+}
+
+// ── Pure helpers (exported for tests) ──────────────────────────────
+
+/**
+ * Compare two CarsonOS versions. Returns -1 if a < b, 0 if equal, 1 if a > b.
+ * Handles both 3-digit (legacy) and 4-digit shapes by zero-padding.
+ */
+export function compareVersions(a: string, b: string): -1 | 0 | 1 {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  const max = Math.max(pa.length, pb.length);
+  for (let i = 0; i < max; i++) {
+    const ai = pa[i] ?? 0;
+    const bi = pb[i] ?? 0;
+    if (ai < bi) return -1;
+    if (ai > bi) return 1;
+  }
+  return 0;
+}
+
+/**
+ * Pull the changelog entry for a given version out of CHANGELOG.md.
+ * The file follows Keep-a-Changelog: each release is a `## [X.Y.Z.W] - YYYY-MM-DD`
+ * header followed by sections. We extract from that header up to the next
+ * `## [` header (or end of file).
+ *
+ * Returns an empty string if the entry isn't found — the CoS prompt
+ * just proceeds without the body in that case.
+ */
+export function extractChangelogEntry(changelog: string, version: string): string {
+  // Match `## [VERSION]` with the version literal regex-escaped.
+  const escaped = version.replace(/[.+*?^${}()|[\]\\]/g, "\\$&");
+  const headerRe = new RegExp(`^## \\[${escaped}\\][^\\n]*$`, "m");
+  const headerMatch = headerRe.exec(changelog);
+  if (!headerMatch) return "";
+  const start = headerMatch.index + headerMatch[0].length;
+  // Find the next `## [` header (start of next entry).
+  const tail = changelog.slice(start);
+  const nextRe = /^## \[/m;
+  const nextMatch = nextRe.exec(tail);
+  const body = nextMatch ? tail.slice(0, nextMatch.index) : tail;
+  return body.trim();
+}
+
+/**
+ * Sanitize a changelog excerpt before injecting it into the CoS system
+ * prompt. The CHANGELOG is editable by anyone with repo write access, so
+ * this is a trust-boundary surface — strip control bytes, cap the size,
+ * keep the prompt bounded.
+ */
+export function sanitizeExcerpt(raw: string): string {
+  // eslint-disable-next-line no-control-regex
+  const stripped = raw.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "");
+  if (stripped.length <= EXCERPT_MAX_BYTES) return stripped;
+  return (
+    stripped.slice(0, EXCERPT_MAX_BYTES - 32) +
+    `\n... [truncated to ${EXCERPT_MAX_BYTES}B]`
+  );
+}
+
+// ── Internal helpers ───────────────────────────────────────────────
+
+function readLocalVersion(): string | null {
+  try {
+    const versionPath = join(import.meta.dirname, "..", "..", "..", "VERSION");
+    return readFileSync(versionPath, "utf-8").trim();
+  } catch {
+    return null;
+  }
+}
+
+async function fetchText(url: string, fetcher?: typeof fetch): Promise<string> {
+  const f = fetcher ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await f(url, { signal: controller.signal });
+    if (!res.ok) {
+      throw new Error(`${url}: HTTP ${res.status}`);
+    }
+    return await res.text();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function readSetting(db: Db, key: string): Promise<unknown> {
+  const [row] = await db
+    .select()
+    .from(instanceSettings)
+    .where(eq(instanceSettings.key, key))
+    .limit(1);
+  return row?.value ?? null;
+}
+
+async function writeSetting(db: Db, key: string, value: unknown): Promise<void> {
+  const existing = await db
+    .select({ id: instanceSettings.id })
+    .from(instanceSettings)
+    .where(eq(instanceSettings.key, key))
+    .limit(1);
+  if (existing.length > 0) {
+    await db
+      .update(instanceSettings)
+      .set({ value })
+      .where(eq(instanceSettings.key, key));
+    return;
+  }
+  await db.insert(instanceSettings).values({
+    id: crypto.randomUUID(),
+    key,
+    value,
+  });
+}
+
+async function deleteSetting(db: Db, key: string): Promise<void> {
+  await db.delete(instanceSettings).where(eq(instanceSettings.key, key));
+}
+
+function isUpdateAvailable(v: unknown): v is UpdateAvailable {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    typeof (v as Record<string, unknown>).from === "string" &&
+    typeof (v as Record<string, unknown>).to === "string" &&
+    typeof (v as Record<string, unknown>).fetchedAt === "string" &&
+    typeof (v as Record<string, unknown>).changelogExcerpt === "string"
+  );
+}
+
+function isUpdatePending(v: unknown): v is UpdatePending {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    typeof (v as Record<string, unknown>).from === "string" &&
+    typeof (v as Record<string, unknown>).to === "string" &&
+    typeof (v as Record<string, unknown>).changelogExcerpt === "string" &&
+    typeof (v as Record<string, unknown>).requestedAt === "string" &&
+    typeof (v as Record<string, unknown>).householdId === "string" &&
+    typeof (v as Record<string, unknown>).requestedByMemberId === "string"
+  );
+}

--- a/server/src/services/tool-registry.ts
+++ b/server/src/services/tool-registry.ts
@@ -27,7 +27,7 @@ import {
   buildToolExecutor,
 } from "./memory/index.js";
 import { SCHEDULING_TOOLS, handleSchedulingTool } from "./scheduling-tools.js";
-import { SELF_TOOLS, STAFF_TOOLS, handleAgentTool } from "./agent-tools.js";
+import { SELF_TOOLS, STAFF_TOOLS, SYSTEM_TOOLS, handleAgentTool } from "./agent-tools.js";
 import { AGENT_GUIDE_TOOLS, handleAgentGuideTool } from "./agent-guides.js";
 import { REDACTION_TOOLS, REDACTION_TOOL_NAMES, handleRedactionTool } from "./redaction-tools.js";
 import {
@@ -238,6 +238,17 @@ export class ToolRegistry {
       this.tools.set(def.name, {
         definition: def,
         category: "agent-staff",
+        tier: "system-chief",
+      });
+    }
+
+    // System tools — CoS-only AND parent-member gated. Trust enforcement
+    // lives inside handleAgentTool (member.role lookup) since `tier` only
+    // captures the CoS axis.
+    for (const def of SYSTEM_TOOLS) {
+      this.tools.set(def.name, {
+        definition: def,
+        category: "agent-system",
         tier: "system-chief",
       });
     }
@@ -689,10 +700,12 @@ export class ToolRegistry {
       }
 
       // Agent management tools (self + staff management for Chief of Staff)
+      // + system tools (apply_system_update, gated to CoS+parent inside the handler).
       const agentToolNames = [
         "update_instructions", "update_personality", "update_role",
         "list_agents", "create_agent", "delete_agent", "pause_agent", "resume_agent", "update_agent_assignment",
         "list_agent_tools", "grant_tool_to_agent", "revoke_tool_from_agent",
+        "apply_system_update",
       ];
       if (agentToolNames.includes(name)) {
         const result = await handleAgentTool(


### PR DESCRIPTION
Second batch of v0.5.1 work — the headline feature. Plan-B split: PR #40 already landed the bugfixes (health probe + QMD observability); this PR lands the CoS-driven update prompt + apply tool + post-restart announcement.

## What this changes

CarsonOS becomes aware of its own pending updates and surfaces them in-voice through the Chief of Staff. Future v0.5.x → v0.6 updates self-announce instead of relying on the operator to remember to run \`update-service.sh\`.

The flow:

1. **Boot + 60s scheduler tick** runs \`checkForUpdate\` against \`https://raw.githubusercontent.com/joshdaws/carson-os/main/VERSION\` (raw HTTP, no git side effects). 24h cache via \`instance_settings\` so the actual fetch fires once a day even though the function gets called every minute.
2. **CoS prompt section** appears when an update is pending. CoS gets instructions to mention it casually if conversation allows, summarize 1-3 user-facing wins from the changelog excerpt, and offer to apply via the \`apply_system_update\` tool.
3. **Trust gate** on \`apply_system_update\`: CoS-only AND requesting member must have \`role='parent'\`. A kid asking for an update gets a polite refusal pointing them at a parent. Pattern matches existing trust hierarchy in \`agent-tools.ts\`.
4. **Restart** spawns \`./scripts/update-service.sh\` detached + writes \`system.update_pending\` state row. Tool returns immediately so the agent can deliver "restart in progress" before its session dies.
5. **Post-restart announcement** runs once on next boot (after \`multiRelay\` is up). If the new VERSION matches what was requested, queues a one-shot wake to CoS via \`engine.processMessage\`, delivers via \`multiRelay.sendMessage\`. Closes the loop in voice on both ends. Uses the same wake infra that v0.5.0's DelegatorReply was built on.

## Architectural decisions (per user input)

- **C** — raw HTTP fetch from GitHub (zero git side effects, zero auth, ~6 bytes of VERSION payload). Stops working if repo goes private; would switch to gh API at that point.
- **B** — full post-restart in-voice announcement, leveraging existing wakeDelegator infra. Closes the loop both directions (CoS proposed it; CoS announces completion).
- **B** — CoS-only + parent-member trust gate. Aligned with existing destructive-tool patterns.

## Files

- **New:** \`services/system-update-check.ts\` (~365 lines). \`checkForUpdate\` fetcher, \`announceUpdateApplied\` post-restart wake driver, pure helpers (\`compareVersions\`, \`extractChangelogEntry\`, \`sanitizeExcerpt\`).
- **New:** \`services/__tests__/system-update-check.test.ts\` (17 tests).
- **Modified:** \`agent-tools.ts\` — new \`SYSTEM_TOOLS\` category + \`handleApplySystemUpdate\` handler with the trust gate.
- **Modified:** \`tool-registry.ts\` — registers SYSTEM_TOOLS at tier \`system-chief\`.
- **Modified:** \`prompt-compiler.ts\` — new \`updateAvailable\` param, renders the CoS instruction section.
- **Modified:** \`constitution-engine.ts\` — reads \`readUpdateAvailable\` for head_butler agents only, threads to compileSystemPrompt.
- **Modified:** \`scheduler.ts\` — adds \`checkForUpdate\` to the per-tick loop.
- **Modified:** \`index.ts\` — boot calls + post-restart announcement.

## Trust-boundary handling

The changelog excerpt flows from raw GitHub content into the CoS prompt. \`sanitizeExcerpt\` strips C0 control bytes and caps at 1500 bytes so a malformed CHANGELOG can't break JSON serialization or balloon the prompt. Anyone with write access to CHANGELOG.md can shape the prompt; the cap + sanitization are the existing trust-boundary surface for prompt content.

## Test plan

- \`pnpm typecheck\` clean
- \`pnpm test\` — **428/428 pass** (was 411 pre-PR; +17 from system-update-check)
- Coverage for compareVersions / extractChangelogEntry (including regex-escape regression) / sanitizeExcerpt / checkForUpdate (cache TTL, malformed remote, fetch failure, write/clear cycles)

## Manual smoke (recommended after merge)

The headline feature can't truly be tested until v0.5.2 ships and the live instance hits this code with a remote ahead. v0.5.1 is the version that adds the awareness; v0.5.0 instances cant benefit retroactively.

1. After merge to main, tag \`v0.5.1\` and push.
2. Run \`./scripts/update-service.sh\` on the live instance.
3. Boot logs should show "[update-check]" entries.
4. Once v0.5.2 work later lands on main, the live instance should detect it within 24h and CoS should mention it on the next conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)