### PR TITLE
fix: v0.5.2 harden update-self-awareness (PR #41 deferreds)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -23,6 +23,10 @@ import { getConfig } from "./config.js";
 import { backupDatabase } from "./services/backup.js";
 import { checkForUpdates } from "./services/update-check.js";
 import { Scheduler } from "./services/scheduler.js";
+import {
+  announceUpdateApplied,
+  checkForUpdate,
+} from "./services/system-update-check.js";
 import { createApp } from "./app.js";
 import { setupWebSocket, broadcast } from "./ws/live-events.js";
 import { AppEventBus } from "./services/event-bus.js";
@@ -618,22 +622,15 @@ async function main() {
   // the user — running earlier would silently fail and defer the
   // announcement to the NEXT boot, defeating the feature on the very
   // boot it's meant to handle.
-  void import("./services/system-update-check.js").then(
-    ({ announceUpdateApplied }) =>
-      announceUpdateApplied(db, {
-        processMessage: (p) =>
-          constitutionEngine.processMessage({
-            ...p,
-            channel: p.channel as "telegram" | "web",
-          }),
-        sendToUser: (agentId, telegramUserId, text) =>
-          multiRelay.sendMessage(agentId, telegramUserId, text),
-      }).catch((err) =>
-        console.warn(
-          "[update-check] boot announcement failed:",
-          err instanceof Error ? err.message : String(err),
-        ),
-      ),
+  announceUpdateApplied(db, {
+    processMessage: (p) => constitutionEngine.processMessage(p),
+    sendToUser: (agentId, telegramUserId, text) =>
+      multiRelay.sendMessage(agentId, telegramUserId, text),
+  }).catch((err) =>
+    console.warn(
+      "[update-check] boot announcement failed:",
+      err instanceof Error ? err.message : String(err),
+    ),
   );
 
   // Hourly sweep of expired hire proposals. Boot-time pass already fired
@@ -715,16 +712,14 @@ async function main() {
 
   // v0.5.1: kick off a non-blocking update check at boot so the CoS knows
   // about pending updates on the first conversation, not 60s after boot.
-  // Inner function self-throttles to 24h via instance_settings TTL.
+  // The function self-throttles to 24h via instance_settings TTL.
   if (process.env.CARSONOS_DISABLE_UPDATE_CHECK !== "1") {
-    void import("./services/system-update-check.js")
-      .then(({ checkForUpdate }) => checkForUpdate(db))
-      .catch((err) =>
-        console.warn(
-          "[update-check] boot check failed:",
-          err instanceof Error ? err.message : String(err),
-        ),
-      );
+    checkForUpdate(db).catch((err) =>
+      console.warn(
+        "[update-check] boot check failed:",
+        err instanceof Error ? err.message : String(err),
+      ),
+    );
   }
 
   // Start listening on loopback only

--- a/server/src/services/__tests__/system-update-check.test.ts
+++ b/server/src/services/__tests__/system-update-check.test.ts
@@ -7,16 +7,48 @@
  * and clear paths are exercised end-to-end without hitting GitHub.
  */
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createDb, type Db } from "@carsonos/db";
 
 import {
+  announceUpdateApplied,
   checkForUpdate,
   compareVersions,
   extractChangelogEntry,
+  readUpdatePending,
   sanitizeExcerpt,
   readUpdateAvailable,
+  writeUpdatePending,
 } from "../system-update-check.js";
+
+// Hooks the spawn-mock can run synchronously between the apply handler's
+// pre-spawn `readUpdateAvailable` and the post-spawn re-read. Used by the
+// race-fix test to simulate a scheduler tick rewriting `update_available`
+// in the apply window. Set inside a test, cleared in afterEach.
+const hoisted = vi.hoisted(() => ({
+  onSpawnHook: null as null | (() => void),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => {
+    hoisted.onSpawnHook?.();
+    return { unref: () => {}, pid: 99999 };
+  }),
+}));
+
+// Apply handler writes a launch log under ~/.carsonos/logs. No-op the
+// three filesystem entry points it touches so tests don't litter the
+// real home directory. readFileSync (used by readLocalVersion) stays
+// real via importActual.
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    mkdirSync: vi.fn(),
+    openSync: vi.fn(() => 9999),
+    closeSync: vi.fn(),
+  };
+});
 
 // ── compareVersions ───────────────────────────────────────────────
 
@@ -447,5 +479,451 @@ describe("apply_system_update trust gate", () => {
     );
     expect(result.is_error).toBe(true);
     expect(result.content).toMatch(/No CarsonOS update is currently available/i);
+  });
+});
+
+// ── checkForUpdate: clock-skew guard (PR #41 deferred) ────────────
+
+describe("checkForUpdate: clock-skew guard", () => {
+  let db: Db;
+  beforeEach(() => {
+    db = createDb(":memory:");
+  });
+
+  it("treats a future last_checked_at as a cache miss and re-fetches", async () => {
+    // Seed the cache row one hour in the future. Without the delta>=0
+    // guard, `Date.now() - lastAt` is negative, which still passes
+    // `< CHECK_TTL_MS` and pins the cache until wall-clock catches up.
+    const { instanceSettings } = await import("@carsonos/db");
+    await db.insert(instanceSettings).values({
+      id: crypto.randomUUID(),
+      key: "system.update_check.last_checked_at",
+      value: { at: new Date(Date.now() + 60 * 60 * 1000).toISOString() },
+    });
+
+    let fetched = 0;
+    const fetcher = (async (input: RequestInfo | URL) => {
+      fetched += 1;
+      const url = String(input);
+      if (url.endsWith("/VERSION")) return new Response("0.5.1");
+      return new Response(SAMPLE_CHANGELOG);
+    }) as typeof fetch;
+
+    const result = await checkForUpdate(db, {
+      currentVersion: "0.5.0",
+      fetcher,
+      // No `force` — the cache gate must decline the future timestamp.
+    });
+
+    expect(fetched).toBeGreaterThan(0);
+    expect(result?.to).toBe("0.5.1");
+  });
+
+  it("still honors a past last_checked_at within the 24h window (no re-fetch)", async () => {
+    // Sanity check: the new clock-skew guard must not break the normal
+    // cache-hit path.
+    const { instanceSettings } = await import("@carsonos/db");
+    await db.insert(instanceSettings).values({
+      id: crypto.randomUUID(),
+      key: "system.update_check.last_checked_at",
+      value: { at: new Date(Date.now() - 60_000).toISOString() }, // 1 min ago
+    });
+
+    let fetched = 0;
+    const fetcher = (async () => {
+      fetched += 1;
+      return new Response("0.5.1");
+    }) as typeof fetch;
+
+    await checkForUpdate(db, {
+      currentVersion: "0.5.0",
+      fetcher,
+    });
+
+    expect(fetched).toBe(0);
+  });
+});
+
+// ── announceUpdateApplied: channel selection (PR #41 deferred) ────
+
+describe("announceUpdateApplied: channel selection", () => {
+  let db: Db;
+  let householdId: string;
+  let cosAgentId: string;
+  let telegramMemberId: string;
+  let webOnlyMemberId: string;
+
+  beforeEach(async () => {
+    db = createDb(":memory:");
+    const { households, familyMembers, staffAgents } = await import("@carsonos/db");
+
+    const [household] = await db
+      .insert(households)
+      .values({ name: "Channel Test" })
+      .returning();
+    householdId = household.id;
+
+    const [tg] = await db
+      .insert(familyMembers)
+      .values({
+        householdId,
+        name: "Telegram Parent",
+        role: "parent",
+        age: 40,
+        telegramUserId: "tg-12345",
+      })
+      .returning();
+    telegramMemberId = tg.id;
+
+    const [web] = await db
+      .insert(familyMembers)
+      .values({
+        householdId,
+        name: "Web Parent",
+        role: "parent",
+        age: 38,
+        // No telegramUserId — should fall through to "web" channel.
+      })
+      .returning();
+    webOnlyMemberId = web.id;
+
+    const [cos] = await db
+      .insert(staffAgents)
+      .values({
+        householdId,
+        name: "Carson",
+        staffRole: "head_butler",
+        roleContent: "CoS for tests",
+        isHeadButler: true,
+      })
+      .returning();
+    cosAgentId = cos.id;
+  });
+
+  it("delivers via telegram when the member has telegramUserId set", async () => {
+    await writeUpdatePending(db, {
+      from: "0.5.0",
+      to: "0.5.1",
+      changelogExcerpt: "test changelog",
+      requestedAt: new Date().toISOString(),
+      householdId,
+      requestedByMemberId: telegramMemberId,
+    });
+
+    const processCalls: Array<{ channel: string; agentId: string; memberId: string }> = [];
+    const sendCalls: Array<{ agentId: string; telegramUserId: string; text: string }> = [];
+
+    await announceUpdateApplied(db, {
+      processMessage: async (input) => {
+        processCalls.push({ channel: input.channel, agentId: input.agentId, memberId: input.memberId });
+        return { response: "Update finished, here's what's new." };
+      },
+      sendToUser: async (agentId, telegramUserId, text) => {
+        sendCalls.push({ agentId, telegramUserId, text });
+      },
+      currentVersion: "0.5.1",
+    });
+
+    expect(processCalls).toHaveLength(1);
+    expect(processCalls[0].channel).toBe("telegram");
+    expect(processCalls[0].agentId).toBe(cosAgentId);
+    expect(processCalls[0].memberId).toBe(telegramMemberId);
+
+    expect(sendCalls).toHaveLength(1);
+    expect(sendCalls[0].telegramUserId).toBe("tg-12345");
+    expect(sendCalls[0].text).toBe("Update finished, here's what's new.");
+
+    // Pending row cleared once the announcement landed.
+    expect(await readUpdatePending(db)).toBeNull();
+  });
+
+  it("delivers via web (no push) when the member has no telegramUserId", async () => {
+    await writeUpdatePending(db, {
+      from: "0.5.0",
+      to: "0.5.1",
+      changelogExcerpt: "test changelog",
+      requestedAt: new Date().toISOString(),
+      householdId,
+      requestedByMemberId: webOnlyMemberId,
+    });
+
+    let processChannel: string | null = null;
+    let sendInvoked = false;
+
+    await announceUpdateApplied(db, {
+      processMessage: async (input) => {
+        processChannel = input.channel;
+        return { response: "Update finished." };
+      },
+      sendToUser: async () => {
+        sendInvoked = true;
+      },
+      currentVersion: "0.5.1",
+    });
+
+    expect(processChannel).toBe("web");
+    // Web channel relies on processMessage's conversation persistence —
+    // the announcement is the assistant message it just wrote, no push.
+    expect(sendInvoked).toBe(false);
+    // Pending still gets cleared so the announcement doesn't re-fire on
+    // the next boot.
+    expect(await readUpdatePending(db)).toBeNull();
+  });
+
+  it("strips the system trigger from the web conversation after delivery", async () => {
+    // Simulate processMessage's behavior: it persists the trigger as a
+    // role="user" row before generating a response. The web announce
+    // path must scrub this so the user doesn't see a "user" bubble
+    // they didn't type when they next open the UI.
+    await writeUpdatePending(db, {
+      from: "0.5.0",
+      to: "0.5.1",
+      changelogExcerpt: "test changelog",
+      requestedAt: new Date().toISOString(),
+      householdId,
+      requestedByMemberId: webOnlyMemberId,
+    });
+
+    const { conversations, messages } = await import("@carsonos/db");
+    const { eq, and, asc } = await import("drizzle-orm");
+
+    let capturedTrigger: string | null = null;
+    await announceUpdateApplied(db, {
+      processMessage: async (input) => {
+        capturedTrigger = input.message;
+        // Stand in for the engine: open or create the web conversation
+        // and append role="user"=trigger then role="assistant"=response,
+        // matching ConstitutionEngine.processMessage's persistence.
+        const [existing] = db
+          .select()
+          .from(conversations)
+          .where(
+            and(
+              eq(conversations.agentId, input.agentId),
+              eq(conversations.memberId, input.memberId),
+              eq(conversations.householdId, input.householdId),
+              eq(conversations.channel, "web"),
+            ),
+          )
+          .all();
+        const convoId =
+          existing?.id ??
+          db
+            .insert(conversations)
+            .values({
+              agentId: input.agentId,
+              memberId: input.memberId,
+              householdId: input.householdId,
+              channel: "web",
+              startedAt: new Date().toISOString(),
+              lastMessageAt: new Date().toISOString(),
+            })
+            .returning({ id: conversations.id })
+            .all()[0].id;
+        db.insert(messages)
+          .values({
+            conversationId: convoId,
+            role: "user",
+            content: input.message,
+          })
+          .run();
+        db.insert(messages)
+          .values({
+            conversationId: convoId,
+            role: "assistant",
+            content: "Update finished, here's what's new.",
+          })
+          .run();
+        return { response: "Update finished, here's what's new." };
+      },
+      sendToUser: async () => {},
+      currentVersion: "0.5.1",
+    });
+
+    // The web conversation should have ONLY the assistant message —
+    // the trigger user row was scrubbed by stripWebChannelTrigger.
+    const [conv] = await db
+      .select({ id: conversations.id })
+      .from(conversations)
+      .where(
+        and(
+          eq(conversations.agentId, cosAgentId),
+          eq(conversations.memberId, webOnlyMemberId),
+          eq(conversations.householdId, householdId),
+          eq(conversations.channel, "web"),
+        ),
+      )
+      .limit(1);
+    expect(conv).toBeTruthy();
+
+    const rows = await db
+      .select({ role: messages.role, content: messages.content })
+      .from(messages)
+      .where(eq(messages.conversationId, conv!.id))
+      .orderBy(asc(messages.createdAt));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].role).toBe("assistant");
+    expect(rows[0].content).toBe("Update finished, here's what's new.");
+    // The trigger we captured was the system-injected one, and it should
+    // no longer be present anywhere in the conversation.
+    expect(capturedTrigger).not.toBeNull();
+    expect(rows.some((r) => r.content === capturedTrigger!)).toBe(false);
+  });
+
+  it("leaves pending in place when the engine returns blocked (retries next boot)", async () => {
+    await writeUpdatePending(db, {
+      from: "0.5.0",
+      to: "0.5.1",
+      changelogExcerpt: "test",
+      requestedAt: new Date().toISOString(),
+      householdId,
+      requestedByMemberId: webOnlyMemberId,
+    });
+
+    await announceUpdateApplied(db, {
+      processMessage: async () => ({ blocked: true }),
+      sendToUser: async () => {
+        throw new Error("must not be called when blocked");
+      },
+      currentVersion: "0.5.1",
+    });
+
+    // Pending NOT cleared — next boot retries.
+    expect(await readUpdatePending(db)).not.toBeNull();
+  });
+});
+
+// ── apply_system_update: read/write race fix (PR #41 deferred) ────
+
+describe("apply_system_update: pending uses freshest update_available", () => {
+  let db: Db;
+  let householdId: string;
+  let parentMemberId: string;
+  let cosAgentId: string;
+
+  beforeEach(async () => {
+    db = createDb(":memory:");
+    hoisted.onSpawnHook = null;
+
+    const { households, familyMembers, staffAgents } = await import("@carsonos/db");
+
+    const [household] = await db
+      .insert(households)
+      .values({ name: "Race Test" })
+      .returning();
+    householdId = household.id;
+
+    const [parent] = await db
+      .insert(familyMembers)
+      .values({ householdId, name: "Parent", role: "parent", age: 40 })
+      .returning();
+    parentMemberId = parent.id;
+
+    const [cos] = await db
+      .insert(staffAgents)
+      .values({
+        householdId,
+        name: "Carson",
+        staffRole: "head_butler",
+        roleContent: "CoS",
+        isHeadButler: true,
+      })
+      .returning();
+    cosAgentId = cos.id;
+
+    // Seed an update_available row pointing 0.5.0 → 0.5.1.
+    const { instanceSettings } = await import("@carsonos/db");
+    await db.insert(instanceSettings).values({
+      id: crypto.randomUUID(),
+      key: "system.update_available",
+      value: {
+        from: "0.5.0",
+        to: "0.5.1",
+        fetchedAt: new Date().toISOString(),
+        changelogExcerpt: "v0.5.1 changelog",
+      },
+    });
+  });
+
+  it("re-reads update_available before writing pending and prefers the freshest row", async () => {
+    // Simulate the scheduler tick rewriting update_available between
+    // our pre-spawn read and post-spawn re-read: main bumped from
+    // 0.5.1 to 0.5.2 in the apply window. Without the re-read,
+    // pending.to would be 0.5.1 (stale).
+    const { instanceSettings } = await import("@carsonos/db");
+    const { eq } = await import("drizzle-orm");
+    hoisted.onSpawnHook = () => {
+      db.update(instanceSettings)
+        .set({
+          value: {
+            from: "0.5.0",
+            to: "0.5.2",
+            fetchedAt: new Date().toISOString(),
+            changelogExcerpt: "v0.5.2 changelog",
+          },
+        })
+        .where(eq(instanceSettings.key, "system.update_available"))
+        .run();
+    };
+
+    const { handleAgentTool } = await import("../agent-tools.js");
+    const result = await handleAgentTool(
+      {
+        db,
+        agentId: cosAgentId,
+        memberId: parentMemberId,
+        memberName: "Parent",
+        householdId,
+        isChiefOfStaff: true,
+      },
+      "apply_system_update",
+      {},
+    );
+
+    expect(result.is_error).toBeFalsy();
+
+    const pending = await readUpdatePending(db);
+    expect(pending).not.toBeNull();
+    expect(pending!.to).toBe("0.5.2");
+    expect(pending!.changelogExcerpt).toBe("v0.5.2 changelog");
+    expect(pending!.requestedByMemberId).toBe(parentMemberId);
+    expect(pending!.householdId).toBe(householdId);
+  });
+
+  it("falls back to the snapshot when the row was cleared during the apply window", async () => {
+    // If the tick clears update_available between our pre-spawn read
+    // and post-spawn re-read, we still want the announcement to fire
+    // on the post-restart boot — the script has already been kicked
+    // off by spawn. Use the original snapshot.
+    const { instanceSettings } = await import("@carsonos/db");
+    const { eq } = await import("drizzle-orm");
+    hoisted.onSpawnHook = () => {
+      db.delete(instanceSettings)
+        .where(eq(instanceSettings.key, "system.update_available"))
+        .run();
+    };
+
+    const { handleAgentTool } = await import("../agent-tools.js");
+    const result = await handleAgentTool(
+      {
+        db,
+        agentId: cosAgentId,
+        memberId: parentMemberId,
+        memberName: "Parent",
+        householdId,
+        isChiefOfStaff: true,
+      },
+      "apply_system_update",
+      {},
+    );
+
+    expect(result.is_error).toBeFalsy();
+
+    const pending = await readUpdatePending(db);
+    expect(pending).not.toBeNull();
+    // Snapshot values from the seeded row.
+    expect(pending!.to).toBe("0.5.1");
+    expect(pending!.changelogExcerpt).toBe("v0.5.1 changelog");
   });
 });

--- a/server/src/services/agent-tools.ts
+++ b/server/src/services/agent-tools.ts
@@ -358,14 +358,27 @@ async function handleApplySystemUpdate(ctx: AgentToolContext): Promise<ToolResul
   }
 
   // Spawn succeeded (the OS reported a pid). Now persist update_pending
-  // so the post-restart announcement can fire. If this DB write fails,
-  // the update will still apply but the new instance won't know to
-  // announce it — log loudly so the operator can investigate.
+  // so the post-restart announcement can fire. Re-read update_available
+  // immediately before the write to pick up any concurrent scheduler-
+  // tick rewrite — e.g., main bumped from 0.5.1 to 0.5.2 between our
+  // pre-spawn read and now. The script is going to git-pull main, so
+  // the freshest known `to` matches what we'll actually land on; using
+  // the stale snapshot would make announceUpdateApplied see
+  // cmp(current, pending.to) > 0 on the post-restart boot and skip the
+  // announcement. If the row was cleared between read and re-read (the
+  // tick decided we're current — rare, only if local VERSION moved),
+  // fall back to the snapshot since spawn already kicked off and we
+  // still want the announcement to fire. SQLite is single-writer, so
+  // re-reading right before write narrows the race window to negligible.
+  // If this write fails, the update will still apply but the new
+  // instance won't know to announce it — log loudly.
   try {
+    const fresh = await readUpdateAvailable(ctx.db);
+    const target = fresh ?? available;
     await writeUpdatePending(ctx.db, {
-      from: available.from,
-      to: available.to,
-      changelogExcerpt: available.changelogExcerpt,
+      from: target.from,
+      to: target.to,
+      changelogExcerpt: target.changelogExcerpt,
       requestedAt: new Date().toISOString(),
       householdId: ctx.householdId,
       requestedByMemberId: ctx.memberId,

--- a/server/src/services/scheduler.ts
+++ b/server/src/services/scheduler.ts
@@ -18,6 +18,7 @@ import type { ConstitutionEngine } from "./constitution-engine.js";
 import type { MultiRelayManager } from "./multi-relay-manager.js";
 import type { MemoryProvider } from "@carsonos/shared";
 import { familyMembers } from "@carsonos/db";
+import { checkForUpdate } from "./system-update-check.js";
 
 const TICK_INTERVAL_MS = 60_000; // Check every 60 seconds
 
@@ -261,7 +262,6 @@ export class Scheduler {
       // and air-gapped deploys.
       if (process.env.CARSONOS_DISABLE_UPDATE_CHECK !== "1") {
         try {
-          const { checkForUpdate } = await import("./system-update-check.js");
           await checkForUpdate(this.db);
         } catch (err) {
           console.warn("[update-check] tick error:", err);

--- a/server/src/services/system-update-check.ts
+++ b/server/src/services/system-update-check.ts
@@ -28,7 +28,7 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { and, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import type { Db } from "@carsonos/db";
 import {
   conversations,
@@ -543,6 +543,13 @@ async function stripWebChannelTrigger(
   householdId: string,
   trigger: string,
 ): Promise<void> {
+  // The (agentId, memberId, householdId, channel) tuple is unique per
+  // ConstitutionEngine.getOrCreateConversation, but the schema has no
+  // UNIQUE constraint to enforce it. Order by lastMessageAt desc so we
+  // always target the freshest row even if duplicates ever creep in
+  // (legacy data, future schema change). Otherwise the strip could
+  // delete from an old conversation while the trigger sits visible in
+  // the active one.
   const [conv] = await db
     .select({ id: conversations.id })
     .from(conversations)
@@ -554,6 +561,7 @@ async function stripWebChannelTrigger(
         eq(conversations.channel, "web"),
       ),
     )
+    .orderBy(desc(conversations.lastMessageAt))
     .limit(1);
   if (!conv) return;
   await db

--- a/server/src/services/system-update-check.ts
+++ b/server/src/services/system-update-check.ts
@@ -28,9 +28,15 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type { Db } from "@carsonos/db";
-import { instanceSettings } from "@carsonos/db";
+import {
+  conversations,
+  familyMembers,
+  instanceSettings,
+  messages,
+  staffAgents,
+} from "@carsonos/db";
 
 // ── Constants ──────────────────────────────────────────────────────
 
@@ -87,12 +93,17 @@ export async function checkForUpdate(
   options: CheckOptions = {},
 ): Promise<UpdateAvailable | null> {
   // Cache gate: skip the network call if we ran in the last 24h, unless
-  // the caller forces a fresh check.
+  // the caller forces a fresh check. The `delta >= 0` clause guards
+  // against clock skew — a future `lastAt` (NTP correction backwards,
+  // operator setting the system clock forward then back) would otherwise
+  // make `delta < TTL` pass and pin the cache until wall-clock catches
+  // up, which can be effectively forever.
   if (!options.force) {
     const last = await readSetting(db, KEY_LAST_CHECKED);
     if (last && typeof last === "object" && "at" in last) {
       const lastAt = new Date((last as { at: string }).at).getTime();
-      if (Number.isFinite(lastAt) && Date.now() - lastAt < CHECK_TTL_MS) {
+      const delta = Date.now() - lastAt;
+      if (Number.isFinite(lastAt) && delta >= 0 && delta < CHECK_TTL_MS) {
         // Cache hit. Return the previously-recorded available state if any.
         const cached = await readSetting(db, KEY_UPDATE_AVAILABLE);
         return isUpdateAvailable(cached) ? cached : null;
@@ -191,7 +202,11 @@ export async function clearUpdatePending(db: Db): Promise<void> {
  * and the sender delivers the result via the matching telegram bot.
  */
 export interface AnnounceUpdateAppliedDeps {
-  /** ConstitutionEngine.processMessage, narrowed. */
+  /** ConstitutionEngine.processMessage, narrowed. The channel is chosen
+   *  here based on the member's primary push transport: "telegram" when
+   *  telegramUserId is set, otherwise "web". The web path doesn't push —
+   *  processMessage's persistence into the conversation IS the delivery
+   *  (the user sees it on next UI open). */
   processMessage: (input: {
     agentId: string;
     memberId: string;
@@ -199,7 +214,10 @@ export interface AnnounceUpdateAppliedDeps {
     message: string;
     channel: "telegram" | "web";
   }) => Promise<{ blocked?: boolean; response?: string }>;
-  /** multiRelay.sendMessage(agentId, telegramUserId, text). */
+  /** multiRelay.sendMessage(agentId, telegramUserId, text). Only invoked
+   *  when channel === "telegram"; web members are delivered passively
+   *  via the conversation persistence above. Signal-only members fall
+   *  through to web for now (TODO-6 handles Signal explicitly). */
   sendToUser: (
     agentId: string,
     telegramUserId: string,
@@ -266,12 +284,7 @@ export async function announceUpdateApplied(
     return;
   }
 
-  // Look up the household's CoS and the requesting member's telegram id.
-  // Local imports kept here so the static import surface of system-update-
-  // check.ts stays minimal.
-  const { staffAgents, familyMembers } = await import("@carsonos/db");
-  const { eq, and } = await import("drizzle-orm");
-
+  // Look up the household's CoS and the requesting member.
   const [cos] = await db
     .select({ id: staffAgents.id })
     .from(staffAgents)
@@ -306,13 +319,12 @@ export async function announceUpdateApplied(
     await clearUpdatePending(db);
     return;
   }
-  if (!member.telegramUserId) {
-    console.warn(
-      `[update-check] post-restart: ${member.name} has no telegram_user_id; skipping announcement`,
-    );
-    await clearUpdatePending(db);
-    return;
-  }
+  // Pick the member's primary push channel. Telegram if a telegramUserId
+  // is set; otherwise fall back to web — processMessage's persistence
+  // into the web conversation IS the delivery (the user sees it on
+  // next UI open). Signal-only members fall through to web for now;
+  // explicit signal-push delivery is TODO-6.
+  const channel: "telegram" | "web" = member.telegramUserId ? "telegram" : "web";
 
   // Build a plain-prose system trigger. The trigger format mirrors
   // wakeDelegator's pattern: tagged key:value lines, no sentinel format,
@@ -338,7 +350,7 @@ export async function announceUpdateApplied(
       memberId: member.id,
       householdId: pending.householdId,
       message: trigger,
-      channel: "telegram",
+      channel,
     });
     if (result.blocked) {
       console.warn("[update-check] post-restart: engine blocked the announcement turn");
@@ -352,10 +364,31 @@ export async function announceUpdateApplied(
       console.warn("[update-check] post-restart: engine returned empty response");
       return;
     }
-    await deps.sendToUser(cos.id, member.telegramUserId, text);
+    if (channel === "telegram") {
+      // member.telegramUserId is non-null here (the channel pick above
+      // gates on it). Push via the agent's bot.
+      await deps.sendToUser(cos.id, member.telegramUserId!, text);
+    } else {
+      // For web, processMessage already persisted the assistant response
+      // into the web conversation row; no push needed. But it ALSO
+      // persisted our trigger as role="user" before generating the
+      // response, and the trigger is system-injected — not a real user
+      // keystroke. Leaving it in the conversation would show the user a
+      // user-bubble with the raw trigger text the next time they open
+      // the UI. Strip it. Telegram doesn't need this scrub: the
+      // telegram client renders bot replies and doesn't surface the
+      // user-side history of bot conversations to its viewer.
+      await stripWebChannelTrigger(
+        db,
+        cos.id,
+        member.id,
+        pending.householdId,
+        trigger,
+      );
+    }
     await clearUpdatePending(db);
     console.log(
-      `[update-check] post-restart announcement delivered to ${member.name} (v${pending.from} → v${current})`,
+      `[update-check] post-restart announcement delivered to ${member.name} via ${channel} (v${pending.from} → v${current})`,
     );
   } catch (err) {
     console.warn(
@@ -494,6 +527,44 @@ async function writeSetting(db: Db, key: string, value: unknown): Promise<void> 
 
 async function deleteSetting(db: Db, key: string): Promise<void> {
   await db.delete(instanceSettings).where(eq(instanceSettings.key, key));
+}
+
+/**
+ * Remove the system-injected trigger row that processMessage wrote into
+ * the web conversation as role="user" before generating its response.
+ * Used only on the web announcement path; telegram doesn't need it
+ * because the telegram viewer shows bot replies, not the user-side
+ * history of bot conversations.
+ */
+async function stripWebChannelTrigger(
+  db: Db,
+  agentId: string,
+  memberId: string,
+  householdId: string,
+  trigger: string,
+): Promise<void> {
+  const [conv] = await db
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(
+      and(
+        eq(conversations.agentId, agentId),
+        eq(conversations.memberId, memberId),
+        eq(conversations.householdId, householdId),
+        eq(conversations.channel, "web"),
+      ),
+    )
+    .limit(1);
+  if (!conv) return;
+  await db
+    .delete(messages)
+    .where(
+      and(
+        eq(messages.conversationId, conv.id),
+        eq(messages.role, "user"),
+        eq(messages.content, trigger),
+      ),
+    );
 }
 
 function isUpdateAvailable(v: unknown): v is UpdateAvailable {


### PR DESCRIPTION
## Summary

Four deferred items from PR #41 (system update self-awareness), sequenced as the first PR of v0.5.2.

### 1. Hoist dynamic imports off the hot path

`scheduler.ts` ran `await import(\"./system-update-check.js\")` on every 60s tick; `index.ts` did the same in two places at boot. Both now import statically. `system-update-check.ts` itself was re-importing `staffAgents`, `familyMembers`, and `and` inside `announceUpdateApplied` even though those names are imported statically elsewhere in the same module; dropped the runtime import block.

### 2. Close the apply_system_update / scheduler race

`handleApplySystemUpdate` previously read `update_available` once before spawning the update script, then wrote `update_pending` from that snapshot after the spawn returned. The 60s tick can rewrite `update_available` in that window (e.g. main bumped from 0.5.1 to 0.5.2). The post-restart boot would then see `cmp(current=0.5.2, pending.to=0.5.1) > 0` and silently drop the announcement.

Fix: re-read `update_available` immediately before writing pending, prefer the freshest row, fall back to the snapshot if the tick cleared the row entirely. SQLite is single-writer, so re-reading right before writing narrows the window to negligible.

### 3. Generalize announceUpdateApplied channel

The post-restart announcement was telegram-only. Members without a `telegramUserId` were skipped. Now: pick `\"telegram\"` if telegramUserId is set, else `\"web\"`. The picked channel goes into processMessage so the response lands in the right conversation row. Telegram still pushes via multiRelay; web relies on the conversation persistence (the user sees the message next time they open the UI).

`processMessage` writes the trigger as a `role=\"user\"` row before generating a response, which would otherwise show a user-bubble the user didn't type. Added a `stripWebChannelTrigger` helper that scrubs the trigger row after delivery on the web path. Telegram doesn't need this scrub because the telegram client doesn't surface user-side bot history.

Signal-only members fall through to web for now; explicit Signal push is TODO-6 in v0.5.2.

### 4. Clock-skew guard on the 24h cache TTL

`checkForUpdate`'s cache gate was `Date.now() - lastAt < CHECK_TTL_MS`. A future `lastAt` (NTP backwards correction, operator setting the clock forward then back, etc.) yields a negative delta that still passes `< TTL`, pinning the cache until wall-clock catches up. Now requires `delta >= 0` too, treating future timestamps as cache miss.

## Test plan

- [x] `pnpm typecheck` (clean)
- [x] `pnpm test` (435 to 443 tests, all passing)
- [x] New coverage:
  - clock-skew: future last_checked_at re-fetches; past stays cached
  - channel: telegram path pushes via sendToUser; web path persists only and skips push; blocked engine leaves pending for next-boot retry
  - web trigger scrub: the system trigger is removed from the conversation after delivery
  - race fix: fresh row wins when the scheduler tick rewrites update_available during apply; snapshot wins when the tick clears the row
- [x] Adversarial code review on diff via subagent (HIGH 1 web-trigger leak found and fixed; HIGH 2 consent vs convergence trade-off documented in comment; MEDIUM was a misread of boot ordering)

## Out of scope

- Signal push for the post-restart announcement (TODO-6, separate PR in v0.5.2)
- VERSION + CHANGELOG bump (v0.5.2 release-cut, separate PR after the rest of v0.5.2 lands)