### PR TITLE
fix: real /api/health adapter probe (v0.5.2 item 2)

### DIFF
--- a/server/src/services/__tests__/adapter-health-check.test.ts
+++ b/server/src/services/__tests__/adapter-health-check.test.ts
@@ -29,14 +29,27 @@ describe("ClaudeAgentSdkAdapter.healthCheck", () => {
     expect(await adapter.healthCheck()).toBe(true);
   });
 
-  it("treats any HTTP status as reachable, not just 2xx", async () => {
-    // The probe is checking DNS+TCP+TLS reachability — endpoint
-    // semantics (404 vs 200) are irrelevant.
-    for (const status of [200, 401, 404, 405, 500]) {
+  it("treats client-status responses as reachable (2xx/3xx/4xx)", async () => {
+    // 401/404/405 still count as reachable — they prove DNS+TCP+TLS+the
+    // Anthropic edge is up. We're verifying the network path, not
+    // endpoint semantics.
+    for (const status of [200, 301, 401, 404, 405]) {
       const fetcher = (async () =>
         new Response(null, { status })) as typeof fetch;
       const adapter = new ClaudeAgentSdkAdapter({ fetcher });
       expect(await adapter.healthCheck()).toBe(true);
+    }
+  });
+
+  it("treats 5xx responses as unhealthy (Anthropic edge up but broken)", async () => {
+    // 5xx means the edge accepted the connection but Anthropic itself
+    // is failing (overload, deploy bug, dependency outage). SDK calls
+    // would fail too — don't lie to /api/health.
+    for (const status of [500, 502, 503, 504]) {
+      const fetcher = (async () =>
+        new Response(null, { status })) as typeof fetch;
+      const adapter = new ClaudeAgentSdkAdapter({ fetcher });
+      expect(await adapter.healthCheck()).toBe(false);
     }
   });
 

--- a/server/src/services/__tests__/adapter-health-check.test.ts
+++ b/server/src/services/__tests__/adapter-health-check.test.ts
@@ -1,42 +1,116 @@
 /**
- * Regression test for the /api/health adapter probe.
+ * /api/health adapter probe behavior.
  *
- * Before v0.5.1 the Claude Agent SDK adapter's healthCheck() shelled out to
- * `which claude` to verify CLI presence. The SDK adapter doesn't actually
- * use the `claude` CLI at runtime (that's only `ClaudeCodeAdapter`), so the
- * probe was a copy-paste vestige that returned false-negatives on hosts
- * where the CLI was installed outside the launchd service PATH (e.g., the
- * official installer at `~/.local/bin/claude`).
- *
- * The fix at subprocess-adapter.ts ClaudeAgentSdkAdapter.healthCheck()
- * dropped the CLI probe and returns `true` unconditionally — the SDK
- * module already loaded successfully if the adapter constructed.
- *
- * This test pins that contract so a future "let's add a probe back" change
- * has to consciously update both this test and the explanation comment.
+ * v0.5.1: replaced a `which claude` CLI probe (false-negative on launchd
+ * PATH) with `return true` (less wrong, but a regression of signal value).
+ * v0.5.2: replaced the unconditional true with a real reachability probe
+ * to api.anthropic.com, cached for ~30s. Auth is not exercised — verifying
+ * the OAuth token requires a real query() call which spends rate-limit
+ * budget; the deeper probe is deferred. The reachability check still
+ * catches the common failures (network outage, DNS/TLS issues, Anthropic
+ * edge down) that the previous behaviors masked.
  */
 
 import { describe, it, expect } from "vitest";
-import { createAdapter } from "../subprocess-adapter.js";
+import {
+  ClaudeAgentSdkAdapter,
+  createAdapter,
+} from "../subprocess-adapter.js";
 
 describe("ClaudeAgentSdkAdapter.healthCheck", () => {
-  it("returns true unconditionally — does not shell out to `which claude`", async () => {
-    const adapter = createAdapter("anthropic-sdk");
-    const originalPath = process.env.PATH;
-    try {
-      // Clear PATH so any vestigial `execFileSync('which', ['claude'])` would
-      // fail. If we ever regress the fix and add a CLI probe back, this test
-      // will catch it because the adapter would return false here.
-      process.env.PATH = "";
-      const healthy = await adapter.healthCheck();
-      expect(healthy).toBe(true);
-    } finally {
-      process.env.PATH = originalPath;
+  it("reports the correct adapter name", () => {
+    expect(createAdapter("anthropic-sdk").name).toBe("claude-agent-sdk");
+  });
+
+  it("returns true when api.anthropic.com responds (reachable)", async () => {
+    const fetcher = (async () =>
+      new Response(null, { status: 405 })) as typeof fetch;
+    const adapter = new ClaudeAgentSdkAdapter({ fetcher });
+    expect(await adapter.healthCheck()).toBe(true);
+  });
+
+  it("treats any HTTP status as reachable, not just 2xx", async () => {
+    // The probe is checking DNS+TCP+TLS reachability — endpoint
+    // semantics (404 vs 200) are irrelevant.
+    for (const status of [200, 401, 404, 405, 500]) {
+      const fetcher = (async () =>
+        new Response(null, { status })) as typeof fetch;
+      const adapter = new ClaudeAgentSdkAdapter({ fetcher });
+      expect(await adapter.healthCheck()).toBe(true);
     }
   });
 
-  it("reports the correct adapter name", () => {
-    const adapter = createAdapter("anthropic-sdk");
-    expect(adapter.name).toBe("claude-agent-sdk");
+  it("returns false when the network call throws (unreachable)", async () => {
+    const fetcher = (async () => {
+      throw new Error("ENETUNREACH");
+    }) as typeof fetch;
+    const adapter = new ClaudeAgentSdkAdapter({ fetcher });
+    expect(await adapter.healthCheck()).toBe(false);
+  });
+
+  it("caches the probe result so back-to-back calls don't re-probe", async () => {
+    let calls = 0;
+    const fetcher = (async () => {
+      calls += 1;
+      return new Response(null, { status: 405 });
+    }) as typeof fetch;
+
+    const adapter = new ClaudeAgentSdkAdapter({ fetcher });
+    expect(await adapter.healthCheck()).toBe(true);
+    expect(await adapter.healthCheck()).toBe(true);
+    expect(await adapter.healthCheck()).toBe(true);
+
+    // First call probes; subsequent calls hit the cache.
+    expect(calls).toBe(1);
+  });
+
+  it("caches negative results too (a flap doesn't hammer the network)", async () => {
+    let calls = 0;
+    const fetcher = (async () => {
+      calls += 1;
+      throw new Error("ENETUNREACH");
+    }) as typeof fetch;
+
+    const adapter = new ClaudeAgentSdkAdapter({ fetcher });
+    expect(await adapter.healthCheck()).toBe(false);
+    expect(await adapter.healthCheck()).toBe(false);
+    expect(calls).toBe(1);
+  });
+
+  it("re-probes after the cache TTL elapses", async () => {
+    let calls = 0;
+    const fetcher = (async () => {
+      calls += 1;
+      return new Response(null, { status: 405 });
+    }) as typeof fetch;
+
+    // 0ms cache TTL forces a fresh probe on every call.
+    const adapter = new ClaudeAgentSdkAdapter({
+      fetcher,
+      cacheTtlMs: 0,
+    });
+    await adapter.healthCheck();
+    await adapter.healthCheck();
+    expect(calls).toBe(2);
+  });
+
+  it("times out a hung request via AbortController (returns false, doesn't hang)", async () => {
+    const fetcher = ((_url: RequestInfo | URL, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new Error("aborted"));
+        });
+      })) as typeof fetch;
+
+    const adapter = new ClaudeAgentSdkAdapter({
+      fetcher,
+      probeTimeoutMs: 50,
+    });
+    const start = Date.now();
+    const result = await adapter.healthCheck();
+    const elapsed = Date.now() - start;
+    expect(result).toBe(false);
+    // Must time out near the configured 50ms, well under the default 5s.
+    expect(elapsed).toBeLessThan(500);
   });
 });

--- a/server/src/services/subprocess-adapter.ts
+++ b/server/src/services/subprocess-adapter.ts
@@ -901,10 +901,14 @@ export class ClaudeAgentSdkAdapter implements Adapter {
         method: "HEAD",
         signal: ctrl.signal,
       });
-      // Any HTTP response — 200, 404, 401, 405, etc. — proves DNS+TCP+TLS
-      // reachability. We're verifying the network path, not endpoint
-      // semantics.
-      return res.status > 0;
+      // Client-side responses (2xx/3xx/4xx) prove DNS+TCP+TLS+the
+      // Anthropic edge is up — we're verifying the network path, not
+      // endpoint semantics, so 401/404/405 still count as reachable.
+      // 5xx however means the edge is up but Anthropic is broken
+      // (overload, deploy bug, dependency outage), and SDK calls would
+      // fail too. Report unhealthy so /api/health doesn't lie. (Codex
+      // P2 review fix, 2026-05-02.)
+      return res.status > 0 && res.status < 500;
     } catch {
       return false;
     } finally {

--- a/server/src/services/subprocess-adapter.ts
+++ b/server/src/services/subprocess-adapter.ts
@@ -442,8 +442,33 @@ function buildMultimodalPrompt(
   })();
 }
 
-class ClaudeAgentSdkAdapter implements Adapter {
+export class ClaudeAgentSdkAdapter implements Adapter {
   name = "claude-agent-sdk";
+
+  /**
+   * /api/health adapter probe (v0.5.2). Cached so /api/health pollers
+   * don't slam the network on every request. Cleared every probe window
+   * (success or failure) so a flap surfaces within at most one window.
+   */
+  private healthCache: { at: number; ok: boolean } | null = null;
+  private readonly fetcher: typeof fetch;
+  private readonly cacheTtlMs: number;
+  private readonly probeTimeoutMs: number;
+  private static readonly DEFAULT_CACHE_TTL_MS = 30_000;
+  private static readonly DEFAULT_PROBE_TIMEOUT_MS = 5_000;
+  private static readonly PROBE_URL = "https://api.anthropic.com/";
+
+  constructor(opts?: {
+    fetcher?: typeof fetch;
+    cacheTtlMs?: number;
+    probeTimeoutMs?: number;
+  }) {
+    this.fetcher = opts?.fetcher ?? fetch;
+    this.cacheTtlMs =
+      opts?.cacheTtlMs ?? ClaudeAgentSdkAdapter.DEFAULT_CACHE_TTL_MS;
+    this.probeTimeoutMs =
+      opts?.probeTimeoutMs ?? ClaudeAgentSdkAdapter.DEFAULT_PROBE_TIMEOUT_MS;
+  }
 
   async execute(params: AdapterExecuteParams): Promise<AdapterExecuteResult> {
     const { systemPrompt, messages, tools, toolExecutor, model, attachments } = params;
@@ -839,17 +864,52 @@ class ClaudeAgentSdkAdapter implements Adapter {
   }
 
   /**
-   * The Agent SDK is an npm package (`@anthropic-ai/claude-agent-sdk`) that
-   * talks to Anthropic via OAuth. It does NOT shell out to the `claude` CLI
-   * at runtime — unlike `ClaudeCodeAdapter`, which does. Probing for the CLI
-   * here was a copy-paste vestige that returned false-negatives on hosts
-   * where the CLI is installed somewhere other than the launchd service
-   * PATH (e.g., the official installer's `~/.local/bin/claude`). The SDK
-   * module already loaded successfully if we got this far — that's the only
-   * runtime dependency this adapter has.
+   * Verify the SDK can actually reach Anthropic. The Agent SDK talks to
+   * Anthropic via OAuth (Claude subscription) over HTTPS; if DNS, TCP,
+   * TLS, or the API edge is down, the SDK can't make calls regardless
+   * of how cleanly the npm module loaded. The pre-v0.5.1 probe shelled
+   * out to `which claude` (a CLI binary the SDK doesn't actually use at
+   * runtime, returning false-negatives on launchd PATH); the v0.5.1 fix
+   * replaced that with `return true` (less wrong but a regression of
+   * signal value).
+   *
+   * This probe issues a HEAD to `api.anthropic.com` with a 5s timeout,
+   * caches the result for 30s, and treats any HTTP response as
+   * reachable (we're checking that we can talk to Anthropic, not that
+   * the path returns 2xx). Auth is NOT exercised — verifying the OAuth
+   * token requires a real `query()` call, which spends rate-limit
+   * budget. A revoked or expired token will still pass this probe;
+   * the next real query reveals it. Acceptable trade-off: the common
+   * failure modes (network outage, DNS/TLS issues, Anthropic edge down)
+   * are covered, and the probe doesn't burn budget on every poll.
    */
   async healthCheck(): Promise<boolean> {
-    return true;
+    const now = Date.now();
+    if (this.healthCache && now - this.healthCache.at < this.cacheTtlMs) {
+      return this.healthCache.ok;
+    }
+    const ok = await this.probeReachability();
+    this.healthCache = { at: now, ok };
+    return ok;
+  }
+
+  private async probeReachability(): Promise<boolean> {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), this.probeTimeoutMs);
+    try {
+      const res = await this.fetcher(ClaudeAgentSdkAdapter.PROBE_URL, {
+        method: "HEAD",
+        signal: ctrl.signal,
+      });
+      // Any HTTP response — 200, 404, 401, 405, etc. — proves DNS+TCP+TLS
+      // reachability. We're verifying the network path, not endpoint
+      // semantics.
+      return res.status > 0;
+    } catch {
+      return false;
+    } finally {
+      clearTimeout(timer);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Replaces v0.5.1's unconditional \`return true\` in \`ClaudeAgentSdkAdapter.healthCheck()\` with a real reachability probe.

- HEAD to \`https://api.anthropic.com/\`, 5s timeout via AbortController
- 30s cache (success or failure) so \`/api/health\` pollers don't hammer the network
- Any HTTP response counts as reachable. The probe verifies DNS+TCP+TLS+the Anthropic edge is up; it doesn't verify the OAuth token

### Why not also probe OAuth

The Agent SDK uses Claude subscription auth; there's no cheap \"validate-my-token\" endpoint. The only real auth probe would be a minimal \`query()\` call, which spends rate-limit budget on every cache miss. The reachability check still catches the common breakage modes (network outage, DNS/TLS issues, Anthropic edge down) that the unconditional true masked. A revoked or expired token will still pass this probe, but the next real query reveals it.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` (435 to 441 server tests, all passing)
- [x] New coverage:
  - reachable: any HTTP status (200, 401, 404, 405, 500) returns true
  - unreachable: fetch throw returns false
  - positive cache: back-to-back calls only probe once
  - negative cache: failures don't hammer the network on retry
  - TTL: re-probes after cache window
  - timeout: hung fetcher honors AbortController, returns false in <500ms