### PR TITLE
fix: QMD reindex backoff after consecutive failures (v0.5.2 item 3)

### DIFF
--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -27,6 +27,10 @@ export interface ReindexHealthSource {
   getReindexHealth(): {
     errorCount: number;
     lastError: { at: string; message: string } | null;
+    /** v0.5.2: consecutive failures since last success. */
+    consecutiveFailures?: number;
+    /** v0.5.2: ISO timestamp when subprocess attempts resume; null when not backed off. */
+    backoffUntil?: string | null;
   };
 }
 

--- a/server/src/services/memory/__tests__/qmd-provider.test.ts
+++ b/server/src/services/memory/__tests__/qmd-provider.test.ts
@@ -360,8 +360,120 @@ describe("QmdMemoryProvider.getReindexHealth", () => {
       expect(health.lastError === null || typeof health.lastError.at === "string").toBe(
         true,
       );
+      // v0.5.2 fields.
+      expect(health.consecutiveFailures).toBe(0);
+      expect(health.backoffUntil).toBeNull();
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
+  });
+});
+
+// ── Reindex backoff (PR #41 deferred) ─────────────────────────────
+
+describe("QmdMemoryProvider — reindex subprocess + backoff", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "qmd-reindex-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("increments errorCount when the qmd binary is unavailable (real subprocess failure)", async () => {
+    // Inject a non-existent binary path so execFile fails for real.
+    // No vi.mock — the test exercises the actual child_process path.
+    const provider = new QmdMemoryProvider(tmp, undefined, {
+      qmdBin: "/nonexistent/qmd-bin-for-test",
+    });
+
+    const before = provider.getReindexHealth();
+    expect(before.errorCount).toBe(0);
+
+    await provider.reindex();
+
+    const after = provider.getReindexHealth();
+    expect(after.errorCount).toBe(1);
+    expect(after.consecutiveFailures).toBe(1);
+    expect(after.lastError).not.toBeNull();
+    expect(after.lastError!.message).toMatch(/qmd-bin-for-test|ENOENT|spawn/i);
+    // Below the threshold — no backoff yet.
+    expect(after.backoffUntil).toBeNull();
+  });
+
+  it("trips into backoff after three consecutive failures", async () => {
+    const provider = new QmdMemoryProvider(tmp, undefined, {
+      qmdBin: "/nonexistent/qmd-bin-for-test",
+    });
+
+    await provider.reindex();
+    await provider.reindex();
+    await provider.reindex();
+
+    const health = provider.getReindexHealth();
+    expect(health.consecutiveFailures).toBe(3);
+    expect(health.errorCount).toBe(3);
+    expect(health.backoffUntil).not.toBeNull();
+    // backoffUntil is within ~5min of now (allow generous slack).
+    const at = new Date(health.backoffUntil!).getTime();
+    const delta = at - Date.now();
+    expect(delta).toBeGreaterThan(0);
+    expect(delta).toBeLessThanOrEqual(5 * 60 * 1000 + 1000);
+  });
+
+  it("subsequent reindex calls during the backoff window do not increment errorCount", async () => {
+    const provider = new QmdMemoryProvider(tmp, undefined, {
+      qmdBin: "/nonexistent/qmd-bin-for-test",
+    });
+
+    // Trip into backoff (3 failures).
+    await provider.reindex();
+    await provider.reindex();
+    await provider.reindex();
+    const tripped = provider.getReindexHealth();
+    expect(tripped.errorCount).toBe(3);
+    expect(tripped.backoffUntil).not.toBeNull();
+
+    // Further calls during the window are no-ops — no subprocess spawn,
+    // no errorCount bump, no consecutiveFailures bump.
+    await provider.reindex();
+    await provider.reindex();
+    const after = provider.getReindexHealth();
+    expect(after.errorCount).toBe(3);
+    expect(after.consecutiveFailures).toBe(3);
+    expect(after.backoffUntil).toBe(tripped.backoffUntil);
+  });
+
+  it("resets consecutiveFailures + clears backoff on first successful run", async () => {
+    // Use the real `qmd` binary if available; otherwise skip. The success
+    // case is the harder branch to exercise without an environmental
+    // dependency. We stub the bin to a no-op shell command to keep the
+    // test hermetic.
+    const noopBin = process.platform === "win32" ? "cmd" : "true";
+    const provider = new QmdMemoryProvider(tmp, undefined, {
+      qmdBin: noopBin,
+    });
+
+    // Manually seed a failure history to verify the reset path.
+    (
+      provider as unknown as {
+        reindexConsecutiveFailures: number;
+        reindexBackoffUntil: number | null;
+        reindexErrorCount: number;
+      }
+    ).reindexConsecutiveFailures = 2;
+    (provider as unknown as { reindexBackoffUntil: number | null }).reindexBackoffUntil =
+      null; // not yet in backoff window — let the success path run
+
+    await provider.reindex();
+
+    const health = provider.getReindexHealth();
+    expect(health.consecutiveFailures).toBe(0);
+    expect(health.backoffUntil).toBeNull();
+    // errorCount is cumulative, not reset on success. Stays at 0 here
+    // because we seeded only consecutive (in-flight tracker), not
+    // errorCount.
   });
 });

--- a/server/src/services/memory/qmd-provider.ts
+++ b/server/src/services/memory/qmd-provider.ts
@@ -686,6 +686,20 @@ export class QmdMemoryProvider implements MemoryProvider {
    * paths (save/update/delete) call it via `void this.reindex().catch(...)`.
    */
   reindex(): Promise<void> {
+    // Backoff gate: skip the subprocess invocation while we're inside
+    // the cooldown window after consecutive failures. The caller still
+    // gets a resolved promise so save/update/delete doesn't block.
+    //
+    // The gate lives here (in the public entry) rather than inside
+    // runReindex so the synchronous `return Promise.resolve()` doesn't
+    // collide with `this.reindexInFlight = this.runReindex()` below.
+    // (Bug fix: the previous implementation set reindexInFlight=null
+    // synchronously inside runReindex, but reindex() then overwrote
+    // it with the resolved promise — wedging the coalescer until
+    // process restart. See review: codex P1, 2026-05-02.)
+    if (this.reindexBackoffUntil && Date.now() < this.reindexBackoffUntil) {
+      return Promise.resolve();
+    }
     if (this.reindexInFlight) {
       this.reindexQueued = true;
       return this.reindexInFlight;
@@ -721,18 +735,10 @@ export class QmdMemoryProvider implements MemoryProvider {
   }
 
   private async runReindex(): Promise<void> {
-    // Backoff gate: skip the subprocess invocation while we're inside
-    // the cooldown window after consecutive failures. The caller still
-    // gets a resolved promise so the save/update/delete flow doesn't
-    // block, and the queued follow-up bookkeeping below still runs so
-    // the next request after the window can re-attempt cleanly.
-    const now = Date.now();
-    if (this.reindexBackoffUntil && now < this.reindexBackoffUntil) {
-      this.reindexInFlight = null;
-      this.reindexQueued = false;
-      return;
-    }
-
+    // Backoff gate moved to reindex() (the public entry) so the
+    // synchronous-skip path doesn't fight with reindexInFlight
+    // assignment. By the time runReindex starts, the gate has
+    // already passed.
     try {
       await execFileAsync(this.qmdBin, ["update"], {
         timeout: UPDATE_TIMEOUT_MS,

--- a/server/src/services/memory/qmd-provider.ts
+++ b/server/src/services/memory/qmd-provider.ts
@@ -31,9 +31,19 @@ import type {
 
 const execFileAsync = promisify(execFile);
 
-const QMD_BIN = "qmd";
+const DEFAULT_QMD_BIN = "qmd";
 const SEARCH_TIMEOUT_MS = 30_000; // qmd query (hybrid) can take 5-10s
 const UPDATE_TIMEOUT_MS = 30_000;
+
+/**
+ * Backoff after consecutive `qmd update` failures (PR #41 deferred).
+ * Without this, every save/update/delete fires a new reindex even when
+ * the subprocess has been failing in a loop — burning CPU and filling
+ * stderr.log with redundant traces. After three consecutive failures,
+ * pause subprocess invocations for five minutes; reset on first success.
+ */
+const REINDEX_BACKOFF_THRESHOLD = 3;
+const REINDEX_BACKOFF_WINDOW_MS = 5 * 60 * 1000;
 
 /** v5 entity types that get two-layer pages + nightly compilation. */
 const ENTITY_TYPES = new Set<string>([
@@ -105,10 +115,25 @@ export class QmdMemoryProvider implements MemoryProvider {
   private reindexQueued = false;
   private reindexErrorCount = 0;
   private lastReindexError: { at: string; message: string } | null = null;
+  /**
+   * Consecutive `qmd update` failures since the last success. When this
+   * reaches REINDEX_BACKOFF_THRESHOLD, runReindex pauses subprocess
+   * invocations until `reindexBackoffUntil` elapses. Reset to 0 on the
+   * first success.
+   */
+  private reindexConsecutiveFailures = 0;
+  private reindexBackoffUntil: number | null = null;
+  /** Path to the qmd CLI. Tests pass a non-existent path to drive failures. */
+  private readonly qmdBin: string;
 
-  constructor(rootDir: string, db?: import("@carsonos/db").Db) {
+  constructor(
+    rootDir: string,
+    db?: import("@carsonos/db").Db,
+    opts?: { qmdBin?: string },
+  ) {
     this.rootDir = rootDir;
     this.db = db ?? null;
+    this.qmdBin = opts?.qmdBin ?? DEFAULT_QMD_BIN;
     mkdirSync(rootDir, { recursive: true });
   }
 
@@ -161,7 +186,7 @@ export class QmdMemoryProvider implements MemoryProvider {
 
     // Check if QMD already has this directory under a different name
     try {
-      const { stdout } = await execFileAsync(QMD_BIN, ["collection", "list"], {
+      const { stdout } = await execFileAsync(this.qmdBin, ["collection", "list"], {
         timeout: SEARCH_TIMEOUT_MS,
       });
 
@@ -181,7 +206,7 @@ export class QmdMemoryProvider implements MemoryProvider {
         for (const existingName of collectionNames) {
           try {
             const { stdout: showOut } = await execFileAsync(
-              QMD_BIN,
+              this.qmdBin,
               ["collection", "show", existingName],
               { timeout: SEARCH_TIMEOUT_MS },
             );
@@ -208,7 +233,7 @@ export class QmdMemoryProvider implements MemoryProvider {
 
     try {
       await execFileAsync(
-        QMD_BIN,
+        this.qmdBin,
         ["collection", "add", dir, "--name", name],
         { timeout: SEARCH_TIMEOUT_MS },
       );
@@ -336,14 +361,14 @@ export class QmdMemoryProvider implements MemoryProvider {
       let stdout: string;
       try {
         ({ stdout } = await execFileAsync(
-          QMD_BIN,
+          this.qmdBin,
           ["query", query, "--json", "-c", qmdCollection],
           { timeout: SEARCH_TIMEOUT_MS },
         ));
       } catch {
         // Hybrid query can fail if embeddings aren't ready — fall back to BM25
         ({ stdout } = await execFileAsync(
-          QMD_BIN,
+          this.qmdBin,
           ["search", query, "--json", "-c", qmdCollection],
           { timeout: SEARCH_TIMEOUT_MS },
         ));
@@ -656,8 +681,11 @@ export class QmdMemoryProvider implements MemoryProvider {
    * during an in-flight run get the same promise. This fixes
    * SQLITE_CONSTRAINT_PRIMARYKEY collisions when many save/update
    * calls fire in a burst.
+   *
+   * Public so tests can drive runReindex directly. Production code
+   * paths (save/update/delete) call it via `void this.reindex().catch(...)`.
    */
-  private reindex(): Promise<void> {
+  reindex(): Promise<void> {
     if (this.reindexInFlight) {
       this.reindexQueued = true;
       return this.reindexInFlight;
@@ -679,26 +707,57 @@ export class QmdMemoryProvider implements MemoryProvider {
   getReindexHealth(): {
     errorCount: number;
     lastError: { at: string; message: string } | null;
+    consecutiveFailures: number;
+    backoffUntil: string | null;
   } {
     return {
       errorCount: this.reindexErrorCount,
       lastError: this.lastReindexError,
+      consecutiveFailures: this.reindexConsecutiveFailures,
+      backoffUntil: this.reindexBackoffUntil
+        ? new Date(this.reindexBackoffUntil).toISOString()
+        : null,
     };
   }
 
   private async runReindex(): Promise<void> {
+    // Backoff gate: skip the subprocess invocation while we're inside
+    // the cooldown window after consecutive failures. The caller still
+    // gets a resolved promise so the save/update/delete flow doesn't
+    // block, and the queued follow-up bookkeeping below still runs so
+    // the next request after the window can re-attempt cleanly.
+    const now = Date.now();
+    if (this.reindexBackoffUntil && now < this.reindexBackoffUntil) {
+      this.reindexInFlight = null;
+      this.reindexQueued = false;
+      return;
+    }
+
     try {
-      await execFileAsync(QMD_BIN, ["update"], {
+      await execFileAsync(this.qmdBin, ["update"], {
         timeout: UPDATE_TIMEOUT_MS,
       });
+      // Success: clear consecutive-failure state so a future flap
+      // gets the full threshold's worth of retries before backing off
+      // again.
+      this.reindexConsecutiveFailures = 0;
+      this.reindexBackoffUntil = null;
     } catch (err) {
       const detailed = formatReindexError(err);
       this.reindexErrorCount += 1;
+      this.reindexConsecutiveFailures += 1;
       this.lastReindexError = { at: new Date().toISOString(), message: detailed };
-      console.warn(
-        `[memory] QMD reindex error (count=${this.reindexErrorCount}):`,
-        detailed,
-      );
+      if (this.reindexConsecutiveFailures >= REINDEX_BACKOFF_THRESHOLD) {
+        this.reindexBackoffUntil = Date.now() + REINDEX_BACKOFF_WINDOW_MS;
+        console.warn(
+          `[memory] QMD reindex backed off after ${this.reindexConsecutiveFailures} consecutive failures; pausing for ${REINDEX_BACKOFF_WINDOW_MS / 1000}s. Last error: ${detailed}`,
+        );
+      } else {
+        console.warn(
+          `[memory] QMD reindex error (count=${this.reindexErrorCount}, consecutive=${this.reindexConsecutiveFailures}):`,
+          detailed,
+        );
+      }
     }
     this.reindexInFlight = null;
     if (this.reindexQueued) {
@@ -706,7 +765,8 @@ export class QmdMemoryProvider implements MemoryProvider {
       // Fire-and-forget the queued run. Errors caught inside runReindex.
       // This is also the self-heal path: a transient subprocess failure
       // is recovered by the next successful invocation, since `qmd update`
-      // re-iterates the file system on every run.
+      // re-iterates the file system on every run. If we're now in a
+      // backoff window, the queued call is a no-op via the gate above.
       void this.reindex();
     }
   }


### PR DESCRIPTION
## Summary

Without backoff, every save/update/delete fires a fresh \`qmd update\` subprocess even when the binary has been failing in a loop — burning CPU, filling stderr.log with redundant traces, and (in the steady-state failure case) leaving the family runtime in a hot retry loop.

- After 3 consecutive failures, pause subprocess invocations for 5 minutes
- Reset on first success
- save/update/delete callers still get a resolved promise so foreground flow doesn't block
- Backoff gate only suppresses the actual subprocess spawn

\`getReindexHealth()\` now also surfaces \`consecutiveFailures\` and \`backoffUntil\` (ISO timestamp). The structural \`ReindexHealthSource\` interface in routes/health.ts gains those as optional fields so /api/health surfaces them without breaking non-QMD providers.

\`QMD_BIN\` is now constructor-injectable (defaults to \`\"qmd\"\`) so the new integration tests drive a real subprocess failure with a non-existent binary path. The existing \`formatReindexError\` tests cover the formatting layer; the new tests verify the counter increment + backoff state machine through the actual child_process ENOENT path.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` (435 to 439 server tests, all passing)
- [x] New coverage:
  - errorCount increments on real subprocess failure (no vi.mock — actual child_process)
  - 3 consecutive failures trip backoff
  - calls during the backoff window do not increment errorCount
  - first success resets consecutiveFailures + clears backoffUntil