### PR TITLE
feat: Signal hire-approval via web deep-link (v0.5.2 item 5 / TODO-6)

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -97,9 +97,18 @@ export async function createApp(deps: AppDeps): Promise<express.Express> {
   // caller has to know + spoof the header explicitly, and browser-initiated
   // requests from our UI always include it automatically. GET/HEAD/OPTIONS
   // bypass the check so read-only traffic stays unaffected.
+  //
+  // /api/approval/redeem is exempted (v0.5.2 / TODO-6): it is reached via a
+  // Signal deep-link that opens an external browser session NOT logged in
+  // to the dashboard, so the Origin/Referer almost certainly won't match.
+  // The HMAC-signed token in the request body IS the auth for that
+  // endpoint — the same-origin gate would just block the documented
+  // tunneled flow (CARSONOS_PUBLIC_BASE_URL) without adding security.
   const STATE_CHANGING = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+  const SAME_ORIGIN_EXEMPT = new Set(["/approval/redeem"]);
   app.use("/api", (req: Request, res: Response, next: NextFunction) => {
     if (!STATE_CHANGING.has(req.method)) return next();
+    if (SAME_ORIGIN_EXEMPT.has(req.path)) return next();
     const origin = req.get("origin") ?? "";
     const referer = req.get("referer") ?? "";
     const refererOk = allowedOrigins.some((o) => referer.startsWith(o + "/"));

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -42,6 +42,7 @@ import { createSettingsRoutes } from "./routes/settings.js";
 import { createProfileRoutes } from "./routes/profiles.js";
 import { createScheduledTaskRoutes } from "./routes/scheduled-tasks.js";
 import { createProjectRoutes } from "./routes/projects.js";
+import { createApprovalRoutes } from "./routes/approval.js";
 
 const __dirname = resolve(fileURLToPath(import.meta.url), "..");
 
@@ -127,6 +128,7 @@ export async function createApp(deps: AppDeps): Promise<express.Express> {
   app.use("/api/households", createMemberRoutes(db));
   app.use("/api/staff", createStaffRoutes({ db, personalityInterviewEngine, multiRelay: deps.multiRelay, signalRelay: deps.signalRelay, delegationService: deps.delegationService }));
   app.use("/api/tasks", createTaskRoutes({ db, taskEngine, oversight, delegationService: deps.delegationService }));
+  app.use("/api/approval", createApprovalRoutes({ db, delegationService: deps.delegationService }));
   app.use(
     "/api/constitution",
     createConstitutionRoutes({ db, constitutionEngine, interviewEngine }),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -307,35 +307,66 @@ async function main() {
   // 6b-1. Workspace provider (v0.4: per-task git worktree + tool sandbox)
   const workspace = new WorkspaceProvider();
 
-  // 6b-2. Telegram send fn for the notifier. multiRelay doesn't exist yet
-  // (boot order: dispatcher → delegation-service → multiRelay), so the send
-  // closure resolves the reference lazily. Until multiRelay is bound, sends
-  // fail loud so the reconciler retries on next boot — never drops a payload.
+  // 6b-2. Send fn for the notifier. multiRelay/signalRelay don't exist
+  // yet (boot order: dispatcher → delegation-service → multiRelay/signal),
+  // so the send closure resolves the references lazily. Until both are
+  // bound, sends fail loud so the reconciler retries on next boot.
+  //
+  // Routing policy:
+  //   - Telegram if telegramUserId is set (replyMarkup honored).
+  //   - Signal if no telegramUserId but signalUuid is set (replyMarkup
+  //     dropped — Signal has no callback queries; v0.5.2 / TODO-6 stamps
+  //     deep-link URLs into payload.signalText for hire-proposal cards).
+  //   - Otherwise return an error so the reconciler doesn't silently drop.
   let multiRelayRef: MultiRelayManager | null = null;
+  let signalRelayRef: SignalRelayManager | null = null;
   const notifierSend: TelegramSendFn = async (args): Promise<TelegramSendResult> => {
-    if (!multiRelayRef) return { ok: false, error: "multiRelay not ready yet" };
+    if (!multiRelayRef && !signalRelayRef) {
+      return { ok: false, error: "no relay ready yet" };
+    }
     const [member] = await db
       .select()
       .from(familyMembers)
       .where(eq(familyMembers.id, args.memberId))
       .limit(1);
-    if (!member?.telegramUserId) {
-      return { ok: false, error: `no telegram user id for member ${args.memberId}` };
+    if (!member) {
+      return { ok: false, error: `member ${args.memberId} not found` };
     }
-    try {
-      const { messageId } = await multiRelayRef.sendMessage(
-        args.agentId,
-        member.telegramUserId,
-        args.text,
-        { replyMarkup: args.replyMarkup },
-      );
-      return { ok: true, messageId };
-    } catch (err) {
-      return {
-        ok: false,
-        error: err instanceof Error ? err.message : String(err),
-      };
+    if (member.telegramUserId && multiRelayRef) {
+      try {
+        const { messageId } = await multiRelayRef.sendMessage(
+          args.agentId,
+          member.telegramUserId,
+          args.text,
+          { replyMarkup: args.replyMarkup },
+        );
+        return { ok: true, messageId };
+      } catch (err) {
+        return {
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
     }
+    // No telegram → try Signal. Use signalText if the payload provided a
+    // Signal-specific body (currently the hire-proposal flow uses this to
+    // include approve/reject deep-link URLs in place of inline buttons).
+    if (member.signalUuid && signalRelayRef) {
+      try {
+        const body = args.signalText ?? args.text;
+        await signalRelayRef.sendMessage(args.agentId, member.signalUuid, body);
+        return { ok: true };
+      } catch (err) {
+        return {
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    }
+    return {
+      ok: false,
+      error: `member ${args.memberId} has no reachable transport (no telegram_user_id, no signal_uuid)`,
+    };
   };
   const notifier = new DelegationNotifier(db, notifierSend);
 
@@ -400,6 +431,7 @@ async function main() {
     engine: constitutionEngine,
     orchestrator,
   });
+  signalRelayRef = signalRelay; // bind the notifier's Signal send target
 
   // 8. Create Express app with all dependencies
   const app = await createApp({

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -518,32 +518,55 @@ async function main() {
           .from(familyMembers)
           .where(eq(familyMembers.id, task.requestedBy))
           .limit(1);
-        if (!member?.telegramUserId) return;
+        if (!member) return;
+        // Pick the member's primary push channel (matches notifierSend
+        // routing). v0.5.2 / TODO-6: Signal-only members reach here
+        // when they approved via the deep-link flow; their follow-up
+        // confirmation goes via Signal too.
+        const channel: "telegram" | "signal" | null = member.telegramUserId
+          ? "telegram"
+          : member.signalUuid
+            ? "signal"
+            : null;
+        if (!channel) return;
 
-        // Stamp the approval card with "✅ Approved" and strip the buttons.
-        // Telegram-path approvals already do this via ctx.editMessageText in
-        // the callback_query handler; this is idempotent-enough (editing to
-        // the same text just returns "not modified"), and it's the ONLY way
-        // to update the card when approval came through the Web UI instead.
-        // Previously the web-approval path left live Approve/Reject buttons
-        // sitting in Telegram — user would tap one later and race the flow.
-        const [notif] = await db
-          .select({ deliveredMessageId: delegationNotifications.deliveredMessageId, payload: delegationNotifications.payload })
-          .from(delegationNotifications)
-          .where(
-            and(
-              eq(delegationNotifications.taskId, data.taskId),
-              eq(delegationNotifications.kind, "hire_proposal"),
-            ),
-          )
-          .limit(1);
-        if (notif?.deliveredMessageId) {
-          const originalText =
-            (notif.payload && typeof notif.payload === "object" && "text" in (notif.payload as Record<string, unknown>)
-              ? String((notif.payload as Record<string, unknown>).text ?? "")
-              : "") || "";
-          const stampedText = `✅ Approved\n\n${originalText}`;
-          await multiRelay.editMessage(task.agentId, member.telegramUserId, notif.deliveredMessageId, stampedText).catch(() => {});
+        // Send a follow-up confirmation message via the member's channel.
+        // Telegram supports markdown-ish formatting; Signal renders plain
+        // text (signalRelay handles any escaping).
+        const sendConfirmation = async (text: string): Promise<void> => {
+          if (channel === "telegram") {
+            await multiRelay.sendMessage(task.agentId, member.telegramUserId!, text);
+          } else {
+            await signalRelay.sendMessage(task.agentId, member.signalUuid!, text);
+          }
+        };
+
+        // Telegram-only: stamp the approval card with "✅ Approved" and
+        // strip the buttons. The callback_query handler already does
+        // this in-place when approval came via Telegram inline button;
+        // this path covers Web-UI and Signal-deep-link approvals where
+        // the original Telegram card (if there was one) would otherwise
+        // sit with live buttons. Signal cards are plain text — nothing
+        // to edit on Signal.
+        if (channel === "telegram") {
+          const [notif] = await db
+            .select({ deliveredMessageId: delegationNotifications.deliveredMessageId, payload: delegationNotifications.payload })
+            .from(delegationNotifications)
+            .where(
+              and(
+                eq(delegationNotifications.taskId, data.taskId),
+                eq(delegationNotifications.kind, "hire_proposal"),
+              ),
+            )
+            .limit(1);
+          if (notif?.deliveredMessageId) {
+            const originalText =
+              (notif.payload && typeof notif.payload === "object" && "text" in (notif.payload as Record<string, unknown>)
+                ? String((notif.payload as Record<string, unknown>).text ?? "")
+                : "") || "";
+            const stampedText = `✅ Approved\n\n${originalText}`;
+            await multiRelay.editMessage(task.agentId, member.telegramUserId!, notif.deliveredMessageId, stampedText).catch(() => {});
+          }
         }
 
         // Pull originalUserRequest out of the hire-proposal metadata. If the
@@ -564,7 +587,7 @@ async function main() {
           const text =
             `✅ **${data.name}** is on staff — ${data.specialty} specialist.\n\n` +
             `Tell me what you want them to work on and I'll delegate it.`;
-          await multiRelay.sendMessage(task.agentId, member.telegramUserId, text);
+          await sendConfirmation(text);
           // Thread the announcement into the agent's conversation so the
           // next turn's resumed SDK session sees "X is on staff" in
           // history. Without this, the system prompt built at session-
@@ -576,7 +599,7 @@ async function main() {
             developerAgentId: data.developerAgentId,
             name: data.name,
             specialty: data.specialty,
-          });
+          }, channel);
           return;
         }
 
@@ -600,13 +623,13 @@ async function main() {
             `✅ **${data.name}** is on staff.\n\n` +
             `I tried to auto-delegate your request (_${originalUserRequest.slice(0, 120)}${originalUserRequest.length > 120 ? "…" : ""}_) but hit: ${delegated.error}\n\n` +
             `Just tell me what you want them to do and I'll retry.`;
-          await multiRelay.sendMessage(task.agentId, member.telegramUserId, text);
+          await sendConfirmation(text);
           await threadHireAnnouncement(db, task.agentId, member.id, text, {
             kind: "hire-approved-auto-delegate-failed",
             developerAgentId: data.developerAgentId,
             name: data.name,
             specialty: data.specialty,
-          });
+          }, channel);
           return;
         }
 
@@ -614,14 +637,14 @@ async function main() {
           `✅ **${data.name}** is on staff — putting them on it now.\n\n` +
           `_${originalUserRequest}_\n\n` +
           `I'll ping you when they're done. Say "kill ${data.name}'s task" to cancel.`;
-        await multiRelay.sendMessage(task.agentId, member.telegramUserId, text);
+        await sendConfirmation(text);
         await threadHireAnnouncement(db, task.agentId, member.id, text, {
           kind: "hire-approved-auto-delegated",
           developerAgentId: data.developerAgentId,
           name: data.name,
           specialty: data.specialty,
           runId: delegated.runId,
-        });
+        }, channel);
       } catch (err) {
         console.error("[events] hire.approved follow-up failed:", err);
       }
@@ -854,15 +877,16 @@ async function threadHireAnnouncement(
   memberId: string,
   text: string,
   metadata: Record<string, unknown>,
+  channel: "telegram" | "signal" = "telegram",
 ): Promise<void> {
   try {
     // Conversation key in the runtime is (agentId, memberId, householdId,
-    // channel) — see ConstitutionEngine.getOrCreateConversation. The
-    // next turn that must see this announcement is the resumed Telegram
-    // turn, so scope to channel="telegram" explicitly. Writing to the
-    // wrong conversation row (e.g., a web conversation when the next
-    // turn comes through Telegram) reintroduces the stale-staff-cache
-    // bug we're closing.
+    // channel) — see ConstitutionEngine.getOrCreateConversation. Scope
+    // to the channel the user actually transacts on so the next turn's
+    // resumed SDK session sees "X is on staff" in history. Writing to
+    // the wrong conversation row reintroduces the stale-staff-cache bug
+    // (Carson telling the user "X isn't on staff yet" right after he
+    // confirmed the hire).
     const [conversation] = await db
       .select({ id: conversations.id })
       .from(conversations)
@@ -870,7 +894,7 @@ async function threadHireAnnouncement(
         and(
           eq(conversations.agentId, agentId),
           eq(conversations.memberId, memberId),
-          eq(conversations.channel, "telegram"),
+          eq(conversations.channel, channel),
         ),
       )
       .orderBy(desc(conversations.lastMessageAt))

--- a/server/src/routes/approval.ts
+++ b/server/src/routes/approval.ts
@@ -1,0 +1,229 @@
+/**
+ * Hire-proposal approval routes for Signal-only family members (v0.5.2 / TODO-6).
+ *
+ * Two surfaces:
+ *
+ *   GET  /api/approval/redeem?token=...
+ *     Renders a tiny standalone HTML confirmation page (no React, no
+ *     /api/login) that shows what action is about to fire and gives the
+ *     user a Confirm button. The page POSTs the token back to redeem.
+ *     Reason for the two-step: messaging clients (including Signal Desktop
+ *     and iOS Signal) speculatively prefetch URL previews; a one-shot GET
+ *     would auto-fire the action whenever the message is rendered.
+ *
+ *   POST /api/approval/redeem  body: { token } (or form-encoded `token=`)
+ *     Validates HMAC + expiry, dispatches to delegation-service's existing
+ *     handleHireApproval / handleHireRejection. Same materialization path
+ *     as the Telegram inline-button flow and the /tasks Web UI buttons.
+ *
+ * Mounted under /api/approval so it sits behind the same loopback bind
+ * as the rest of the API. The deep-link host is configurable via
+ * CARSONOS_PUBLIC_BASE_URL when the operator runs a tunnel (Tailscale,
+ * cloudflared) so phones outside the LAN can hit the page.
+ */
+
+import express, { Router, type Request, type Response } from "express";
+import { eq } from "drizzle-orm";
+import type { Db } from "@carsonos/db";
+import { tasks } from "@carsonos/db";
+import type { DelegationService } from "../services/delegation-service.js";
+import { verifyApprovalToken } from "../services/approval-token.js";
+
+export interface ApprovalRouteDeps {
+  db: Db;
+  delegationService: DelegationService;
+}
+
+/** Minimal HTML escape for the few user-controlled strings we render
+ *  server-side (task title + status). The redemption page is otherwise
+ *  static. */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function htmlPage(args: {
+  title: string;
+  bodyHtml: string;
+  status?: number;
+}): { status: number; html: string } {
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>${escapeHtml(args.title)}</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 480px; margin: 0 auto; padding: 24px; line-height: 1.5; color: #1a1a1a; background: #fafafa; }
+    h1 { font-size: 1.4em; margin: 0 0 16px; }
+    .card { padding: 16px; background: #fff; border: 1px solid #e0e0e0; border-radius: 8px; margin: 16px 0; }
+    .meta { color: #666; font-size: 0.9em; }
+    button { padding: 14px 28px; font-size: 16px; border-radius: 6px; border: none; cursor: pointer; font-weight: 500; }
+    button.approve { background: #2ecc71; color: white; }
+    button.reject { background: #e74c3c; color: white; }
+    .actions { margin-top: 24px; }
+    .secondary { display: inline-block; margin-left: 16px; color: #666; text-decoration: none; }
+    .error { color: #c0392b; }
+  </style>
+</head>
+<body>
+  ${args.bodyHtml}
+</body>
+</html>`;
+  return { status: args.status ?? 200, html };
+}
+
+export function createApprovalRoutes(deps: ApprovalRouteDeps): Router {
+  const { db, delegationService } = deps;
+  const router = Router();
+  const formParser = express.urlencoded({ extended: false });
+
+  // GET /api/approval/redeem?token=... — the confirmation page.
+  router.get("/redeem", async (req: Request, res: Response) => {
+    const token = typeof req.query.token === "string" ? req.query.token : "";
+    if (!token) {
+      const { status, html } = htmlPage({
+        title: "Invalid link",
+        bodyHtml: `<h1>Invalid link</h1><p class="error">No approval token provided.</p>`,
+        status: 400,
+      });
+      res.status(status).type("html").send(html);
+      return;
+    }
+
+    const verification = await verifyApprovalToken(db, token);
+    if (!verification.ok) {
+      const { status, html } = htmlPage({
+        title: "Link expired or invalid",
+        bodyHtml: `<h1>Link expired or invalid</h1><p class="error">${escapeHtml(verification.reason)}</p><p>Ask the agent to repropose if you still want to act on this.</p>`,
+        status: 400,
+      });
+      res.status(status).type("html").send(html);
+      return;
+    }
+
+    const { taskId, action } = verification.payload;
+    const [task] = await db
+      .select({
+        id: tasks.id,
+        title: tasks.title,
+        status: tasks.status,
+      })
+      .from(tasks)
+      .where(eq(tasks.id, taskId))
+      .limit(1);
+
+    if (!task) {
+      const { status, html } = htmlPage({
+        title: "Task not found",
+        bodyHtml: `<h1>Task not found</h1><p class="error">This proposal may have expired.</p>`,
+        status: 404,
+      });
+      res.status(status).type("html").send(html);
+      return;
+    }
+
+    if (task.status !== "pending") {
+      const { status, html } = htmlPage({
+        title: "Already resolved",
+        bodyHtml: `<h1>Already resolved</h1><p>This hire proposal is already <strong>${escapeHtml(task.status)}</strong>. No further action needed.</p>`,
+        status: 409,
+      });
+      res.status(status).type("html").send(html);
+      return;
+    }
+
+    const buttonClass = action === "approve" ? "approve" : "reject";
+    const buttonLabel = action === "approve" ? "Approve hire" : "Reject hire";
+    const { status, html } = htmlPage({
+      title: `Confirm: ${action} hire`,
+      bodyHtml: `
+  <h1>${action === "approve" ? "Approve this hire?" : "Reject this hire?"}</h1>
+  <div class="card">
+    <strong>${escapeHtml(task.title)}</strong>
+    <div class="meta">Task ${escapeHtml(task.id)}</div>
+  </div>
+  <p>Tap below to confirm. Closing this page or navigating away cancels.</p>
+  <form method="POST" action="/api/approval/redeem" class="actions">
+    <input type="hidden" name="token" value="${escapeHtml(token)}">
+    <button type="submit" class="${buttonClass}">${escapeHtml(buttonLabel)}</button>
+  </form>`,
+    });
+    res.status(status).type("html").send(html);
+  });
+
+  // POST /api/approval/redeem — actually executes the action.
+  // Accepts both JSON (programmatic clients) and form-encoded (the HTML
+  // page above). Returns JSON for the JSON path, HTML for the form path.
+  router.post("/redeem", formParser, express.json(), async (req: Request, res: Response) => {
+    const token = typeof req.body?.token === "string" ? req.body.token : "";
+    const isForm = req.is("application/x-www-form-urlencoded") !== false &&
+      req.is("application/x-www-form-urlencoded") !== null;
+
+    if (!token) {
+      if (isForm) {
+        const { status, html } = htmlPage({
+          title: "Invalid request",
+          bodyHtml: `<h1>Invalid request</h1><p class="error">No token provided.</p>`,
+          status: 400,
+        });
+        res.status(status).type("html").send(html);
+      } else {
+        res.status(400).json({ error: "token required" });
+      }
+      return;
+    }
+
+    const verification = await verifyApprovalToken(db, token);
+    if (!verification.ok) {
+      if (isForm) {
+        const { status, html } = htmlPage({
+          title: "Link expired or invalid",
+          bodyHtml: `<h1>Link expired or invalid</h1><p class="error">${escapeHtml(verification.reason)}</p>`,
+          status: 400,
+        });
+        res.status(status).type("html").send(html);
+      } else {
+        res.status(400).json({ error: verification.reason });
+      }
+      return;
+    }
+
+    const { taskId, action } = verification.payload;
+    const result =
+      action === "approve"
+        ? await delegationService.handleHireApproval(taskId, "signal-deeplink")
+        : await delegationService.handleHireRejection(taskId, "signal-deeplink");
+
+    if (!result.ok) {
+      if (isForm) {
+        const { status, html } = htmlPage({
+          title: "Action failed",
+          bodyHtml: `<h1>Action failed</h1><p class="error">${escapeHtml(result.error)}</p>`,
+          status: 400,
+        });
+        res.status(status).type("html").send(html);
+      } else {
+        res.status(400).json({ error: result.error });
+      }
+      return;
+    }
+
+    if (isForm) {
+      const { status, html } = htmlPage({
+        title: action === "approve" ? "Hire approved" : "Hire rejected",
+        bodyHtml: `<h1>${action === "approve" ? "Approved" : "Rejected"}</h1><p>The agent will pick this up on their next interaction.</p>`,
+      });
+      res.status(status).type("html").send(html);
+    } else {
+      res.json({ ok: true, action, result });
+    }
+  });
+
+  return router;
+}

--- a/server/src/services/__tests__/approval-token.test.ts
+++ b/server/src/services/__tests__/approval-token.test.ts
@@ -1,0 +1,118 @@
+/**
+ * HMAC approval-token sign/verify (v0.5.2 / TODO-6).
+ *
+ * The token is the auth for Signal-deeplink hire approvals — a Signal-
+ * only family member can't tap inline buttons, so the proposal card
+ * carries two URLs (one per action), each containing a signed token
+ * that the redeem endpoint validates before dispatching to
+ * delegation-service.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createDb, type Db } from "@carsonos/db";
+import {
+  signApprovalToken,
+  verifyApprovalToken,
+} from "../approval-token.js";
+
+describe("approval-token", () => {
+  let db: Db;
+
+  beforeEach(() => {
+    db = createDb(":memory:");
+  });
+
+  it("signs and verifies a valid token round-trip", async () => {
+    const token = await signApprovalToken(db, "task-123", "approve");
+    const result = await verifyApprovalToken(db, token);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload.taskId).toBe("task-123");
+      expect(result.payload.action).toBe("approve");
+      expect(result.payload.expiresAt).toBeGreaterThan(Date.now());
+    }
+  });
+
+  it("signs distinct tokens for approve vs reject on the same task", async () => {
+    const a = await signApprovalToken(db, "task-1", "approve");
+    const r = await signApprovalToken(db, "task-1", "reject");
+    expect(a).not.toBe(r);
+
+    const va = await verifyApprovalToken(db, a);
+    const vr = await verifyApprovalToken(db, r);
+    expect(va.ok && va.payload.action).toBe("approve");
+    expect(vr.ok && vr.payload.action).toBe("reject");
+  });
+
+  it("rejects malformed tokens", async () => {
+    const cases = [
+      "",
+      "no-dots",
+      "two.parts",
+      "task.invalid-action.123.deadbeef",
+      "task.approve.not-a-number.deadbeef",
+    ];
+    for (const t of cases) {
+      const r = await verifyApprovalToken(db, t);
+      expect(r.ok).toBe(false);
+    }
+  });
+
+  it("rejects a tampered signature", async () => {
+    const token = await signApprovalToken(db, "task-x", "approve");
+    const parts = token.split(".");
+    parts[3] = "0".repeat(parts[3].length); // wipe sig
+    const tampered = parts.join(".");
+    const result = await verifyApprovalToken(db, tampered);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("signature mismatch");
+  });
+
+  it("rejects an expired token", async () => {
+    // 1ms TTL — by the time we await + call verify, it's expired.
+    const token = await signApprovalToken(db, "task-expired", "approve", 1);
+    await new Promise((r) => setTimeout(r, 5));
+    const result = await verifyApprovalToken(db, token);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("token expired");
+  });
+
+  it("rejects a token swapped to a different action (signature is action-bound)", async () => {
+    const token = await signApprovalToken(db, "task-swap", "approve");
+    // Take the signature from an approve token and try to use it on a
+    // forged reject body.
+    const parts = token.split(".");
+    parts[1] = "reject"; // forge action
+    const forged = parts.join(".");
+    const result = await verifyApprovalToken(db, forged);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("signature mismatch");
+  });
+
+  it("rejects a token swapped to a different taskId (signature is task-bound)", async () => {
+    const token = await signApprovalToken(db, "task-A", "approve");
+    const parts = token.split(".");
+    parts[0] = "task-B"; // forge taskId
+    const forged = parts.join(".");
+    const result = await verifyApprovalToken(db, forged);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("signature mismatch");
+  });
+
+  it("uses the same secret across calls (tokens stay valid across ::sign+verify)", async () => {
+    // Signing creates the secret on first call. A second sign + verify
+    // pair must use the same secret so verification still passes.
+    const t1 = await signApprovalToken(db, "task-1", "approve");
+    const t2 = await signApprovalToken(db, "task-2", "reject");
+    expect((await verifyApprovalToken(db, t1)).ok).toBe(true);
+    expect((await verifyApprovalToken(db, t2)).ok).toBe(true);
+  });
+
+  it("a token signed in one DB does not verify against a different DB (different secret)", async () => {
+    const tokenA = await signApprovalToken(db, "task-1", "approve");
+    const dbB = createDb(":memory:");
+    const result = await verifyApprovalToken(dbB, tokenA);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("signature mismatch");
+  });
+});

--- a/server/src/services/approval-token.ts
+++ b/server/src/services/approval-token.ts
@@ -1,0 +1,134 @@
+/**
+ * Signed approval tokens for hire-proposal deep-links (v0.5.2 / TODO-6).
+ *
+ * Signal-only family members can't tap inline buttons (Signal protocol
+ * doesn't support callback queries). The Signal hire-proposal card now
+ * includes two deep-link URLs — one for approve, one for reject — that
+ * carry an HMAC-SHA256-signed token. Tapping a link opens a confirmation
+ * page in the family member's browser; the page POSTs the token back to
+ * /api/approval/redeem which validates the signature, checks expiry, and
+ * dispatches to delegation-service.handleHireApproval / handleHireRejection.
+ *
+ * Why HMAC and not a session cookie: the user clicks a link from their
+ * messaging client. They may or may not be logged in to the web UI. The
+ * token IS the auth — server-issued, time-bound, action-bound, taskId-
+ * bound. Stealing the link from a notification preview is enough for an
+ * attacker who already has Signal access; protecting against compromised
+ * messaging clients is out of scope for the family runtime.
+ *
+ * Secret lifecycle: stored under instance_settings.system.approval_token_secret.
+ * Generated lazily on first sign/verify call; persists across restarts.
+ * The operator can rotate by deleting the row (next call regenerates,
+ * invalidating any in-flight tokens — the user just gets a fresh hire
+ * proposal next time the approval window expires).
+ */
+
+import { createHmac, randomBytes } from "node:crypto";
+import { eq } from "drizzle-orm";
+import type { Db } from "@carsonos/db";
+import { instanceSettings } from "@carsonos/db";
+
+const SECRET_KEY = "system.approval_token_secret";
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export type ApprovalAction = "approve" | "reject";
+
+export interface ApprovalTokenPayload {
+  taskId: string;
+  action: ApprovalAction;
+  expiresAt: number;
+}
+
+export type VerifyResult =
+  | { ok: true; payload: ApprovalTokenPayload }
+  | { ok: false; reason: string };
+
+async function getOrCreateSecret(db: Db): Promise<string> {
+  const [row] = await db
+    .select()
+    .from(instanceSettings)
+    .where(eq(instanceSettings.key, SECRET_KEY))
+    .limit(1);
+  const value = row?.value as { secret?: string } | null | undefined;
+  if (value && typeof value.secret === "string" && value.secret.length >= 32) {
+    return value.secret;
+  }
+  const secret = randomBytes(32).toString("hex");
+  if (row) {
+    await db
+      .update(instanceSettings)
+      .set({ value: { secret, generatedAt: new Date().toISOString() } })
+      .where(eq(instanceSettings.key, SECRET_KEY));
+  } else {
+    await db.insert(instanceSettings).values({
+      id: crypto.randomUUID(),
+      key: SECRET_KEY,
+      value: { secret, generatedAt: new Date().toISOString() },
+    });
+  }
+  return secret;
+}
+
+function computeSignature(taskId: string, action: ApprovalAction, expiresAt: number, secret: string): string {
+  return createHmac("sha256", secret)
+    .update(`${taskId}.${action}.${expiresAt}`)
+    .digest("hex");
+}
+
+/**
+ * Sign a fresh approval token for (taskId, action). Pure of network IO
+ * apart from one DB read (cached via the Drizzle query, not by us — the
+ * hot path during proposeHire calls this twice per proposal, which is
+ * fine).
+ */
+export async function signApprovalToken(
+  db: Db,
+  taskId: string,
+  action: ApprovalAction,
+  ttlMs: number = DEFAULT_TTL_MS,
+): Promise<string> {
+  const secret = await getOrCreateSecret(db);
+  const expiresAt = Date.now() + ttlMs;
+  const sig = computeSignature(taskId, action, expiresAt, secret);
+  return `${taskId}.${action}.${expiresAt}.${sig}`;
+}
+
+/**
+ * Validate a token's signature, format, and expiry. Returns the embedded
+ * payload on success, a structured reason on failure (so the route handler
+ * can respond with a precise error code without leaking secret details).
+ */
+export async function verifyApprovalToken(
+  db: Db,
+  token: string,
+): Promise<VerifyResult> {
+  const parts = token.split(".");
+  if (parts.length !== 4) {
+    return { ok: false, reason: "malformed token" };
+  }
+  const [taskId, actionRaw, expiresAtRaw, sig] = parts;
+  if (actionRaw !== "approve" && actionRaw !== "reject") {
+    return { ok: false, reason: "invalid action" };
+  }
+  const expiresAt = Number(expiresAtRaw);
+  if (!Number.isFinite(expiresAt) || expiresAt <= 0) {
+    return { ok: false, reason: "invalid expiry" };
+  }
+  const secret = await getOrCreateSecret(db);
+  const expected = computeSignature(taskId, actionRaw, expiresAt, secret);
+  if (sig.length !== expected.length) {
+    return { ok: false, reason: "signature mismatch" };
+  }
+  // Constant-time comparison to avoid leaking signature length via timing.
+  let diff = 0;
+  for (let i = 0; i < sig.length; i++) {
+    diff |= sig.charCodeAt(i) ^ expected.charCodeAt(i);
+  }
+  if (diff !== 0) {
+    return { ok: false, reason: "signature mismatch" };
+  }
+  if (Date.now() > expiresAt) {
+    return { ok: false, reason: "token expired" };
+  }
+  return { ok: true, payload: { taskId, action: actionRaw, expiresAt } };
+}

--- a/server/src/services/delegation-service.ts
+++ b/server/src/services/delegation-service.ts
@@ -41,6 +41,7 @@ import {
   composeGenericSpecialistInstructions,
 } from "./delegation/specialty-templates/index.js";
 import type { DelegationNotifier, NotifyPayload } from "./delegation/notifier.js";
+import { signApprovalToken } from "./approval-token.js";
 
 // -- Types -----------------------------------------------------------
 
@@ -538,10 +539,33 @@ export class DelegationService {
           ],
         ],
       };
+
+      // v0.5.2 (TODO-6): build a Signal-flavored card body that includes
+      // tap-to-act deep-links instead of inline buttons. Signal-only
+      // members fall through to this path in the boot's notifierSend
+      // routing. The tokens are HMAC-signed and time-bound; tapping a
+      // link opens a confirmation page that POSTs back to redeem.
+      const baseUrl = (
+        process.env.CARSONOS_PUBLIC_BASE_URL ??
+        `http://127.0.0.1:${process.env.PORT ?? "3300"}`
+      ).replace(/\/$/, "");
+      const approveToken = await signApprovalToken(this.db, approvalTask.id, "approve");
+      const rejectToken = await signApprovalToken(this.db, approvalTask.id, "reject");
+      const approveUrl = `${baseUrl}/api/approval/redeem?token=${encodeURIComponent(approveToken)}`;
+      const rejectUrl = `${baseUrl}/api/approval/redeem?token=${encodeURIComponent(rejectToken)}`;
+      const signalText = [
+        cardText,
+        "",
+        "Tap to approve or reject (each link confirms before acting):",
+        `Approve: ${approveUrl}`,
+        `Reject:  ${rejectUrl}`,
+      ].join("\n");
+
       const payload: NotifyPayload = {
         kind: "hire_proposal",
         text: cardText,
         replyMarkup,
+        signalText,
         householdId: input.householdId,
         memberId: input.proposedByMemberId,
         agentId: input.proposedByAgentId,

--- a/server/src/services/delegation/notifier.ts
+++ b/server/src/services/delegation/notifier.ts
@@ -44,6 +44,11 @@ export interface NotifyPayload {
   /** Inline buttons for approval cards. Shape intentionally unknown at this
    * layer — Lane F (Telegram callbacks) defines the exact type. */
   replyMarkup?: unknown;
+  /** v0.5.2 (TODO-6): alternate body for Signal delivery. Signal can't
+   * render inline buttons, so hire-proposal cards include URL deep-links
+   * here that the Signal-only flow uses in place of replyMarkup. When
+   * unset, the regular `text` is sent on either transport. */
+  signalText?: string;
   /** Routing: which household / member / agent's bot sends this. */
   householdId: string;
   memberId: string;
@@ -61,6 +66,10 @@ export type TelegramSendFn = (args: {
   memberId: string;
   text: string;
   replyMarkup?: unknown;
+  /** v0.5.2 (TODO-6): the alternate body to use when this member is
+   *  reached via Signal instead of Telegram. Routing is the send fn's
+   *  responsibility; the notifier just passes the field through. */
+  signalText?: string;
 }) => Promise<TelegramSendResult>;
 
 export interface DeliverResult {
@@ -178,6 +187,7 @@ export class DelegationNotifier {
         memberId: payload.memberId,
         text: payload.text,
         replyMarkup: payload.replyMarkup,
+        signalText: payload.signalText,
       });
     } catch (err) {
       return {


### PR DESCRIPTION
## Summary

Signal-only family members couldn't approve hire proposals before. \`notifierSend\` short-circuited on missing \`telegramUserId\`, the proposal card never landed, and Phase-2 reconciler retried forever every boot/hourly sweep with no user-facing error surface.

Implements option (a) from TODOS.md: deep-link to a web confirmation page with HMAC-signed approve/reject tokens.

## Pieces

- **\`services/approval-token.ts\`** — HMAC-SHA256 sign/verify with a server secret stored in \`instance_settings.system.approval_token_secret\` (generated lazily on first use). Tokens encode \`(taskId, action, expiresAt)\` with a 24h TTL. Constant-time signature comparison.

- **\`routes/approval.ts\`** — Two surfaces:
  - \`GET /api/approval/redeem?token=...\` renders a standalone HTML confirmation page (no React, no auth — the token IS the auth).
  - \`POST /api/approval/redeem\` validates and dispatches to \`delegationService.handleHireApproval\` / \`handleHireRejection\`. Same materialization path as Telegram inline buttons + Web UI buttons.
  - Two-step (page → confirm → POST) because messaging clients prefetch URL previews; a one-shot GET-fires-action would auto-approve every time the message renders.

- **\`delegation-service.proposeHire\`** — signs approve+reject tokens, builds URLs from \`CARSONOS_PUBLIC_BASE_URL\` (defaults to \`http://127.0.0.1:\${PORT}\`), and stamps a Signal-flavored card body into \`payload.signalText\` with the URLs in place of inline buttons.

- **\`notifier\`** — \`NotifyPayload.signalText\` and \`TelegramSendFn.signalText\` optional fields. The notifier just passes them through; routing decides which body to use.

- **\`index.ts notifierSend\`** — routes Telegram-first if \`telegramUserId\` is set, falls back to Signal if \`signalUuid\` is set (using \`signalText\` when present), returns a structured error otherwise so the reconciler doesn't silently drop.

## Network reachability

The family runtime binds loopback by default (\`127.0.0.1\`). Phones won't reach \`http://127.0.0.1:3300\` from outside the host. When the operator runs a tunnel (Tailscale, cloudflared, ngrok), set \`CARSONOS_PUBLIC_BASE_URL\` to the public URL. Without it, the deep-links work only from the host machine — usable as a manual approval UX (open the link on the laptop) but not optimal for phone-only use cases. The Web UI integration into \`/tasks\` is out of scope for v0.5.2.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` (435 to 444 server tests, all passing)
- [x] New coverage:
  - HMAC roundtrip (sign + verify)
  - distinct tokens for approve vs reject on the same task
  - rejects malformed tokens (no dots, wrong action enum, non-numeric expiry)
  - rejects tampered signatures
  - rejects expired tokens
  - rejects forged action swaps (signature is action-bound)
  - rejects forged taskId swaps (signature is task-bound)
  - signing creates the secret on first call; subsequent verifies see the same secret
  - tokens from one DB don't verify against a different DB (secret isolation)