### PR TITLE
[codex] Fix settings secret value exposure

### DIFF
--- a/server/src/routes/__tests__/settings.test.ts
+++ b/server/src/routes/__tests__/settings.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { publicSettingsFromRows } from "../settings.js";
+
+describe("publicSettingsFromRows", () => {
+  it("redacts saved secret setting values and reports presence separately", () => {
+    const { settings, savedSecretKeys } = publicSettingsFromRows([
+      { key: "HOUSEHOLD_NAME", value: "Carson" },
+      { key: "GROQ_API_KEY", value: "gsk_secret_value" },
+      { key: "ANTHROPIC_API_KEY", value: "sk-ant-secret-value" },
+    ]);
+
+    expect(settings).toEqual({
+      HOUSEHOLD_NAME: "Carson",
+      GROQ_API_KEY: "",
+      ANTHROPIC_API_KEY: "",
+    });
+    expect(savedSecretKeys).toEqual(["GROQ_API_KEY", "ANTHROPIC_API_KEY"]);
+  });
+
+  it("does not report empty secret settings as saved", () => {
+    const { settings, savedSecretKeys } = publicSettingsFromRows([
+      { key: "GROQ_API_KEY", value: "" },
+    ]);
+
+    expect(settings).toEqual({ GROQ_API_KEY: "" });
+    expect(savedSecretKeys).toEqual([]);
+  });
+
+  it("does not redact unknown non-secret settings", () => {
+    const { settings, savedSecretKeys } = publicSettingsFromRows([
+      { key: "ADAPTER_TYPE", value: "anthropic-sdk" },
+      { key: "CUSTOM_HEADER", value: "not-classified-as-secret" },
+    ]);
+
+    expect(settings).toEqual({
+      ADAPTER_TYPE: "anthropic-sdk",
+      CUSTOM_HEADER: "not-classified-as-secret",
+    });
+    expect(savedSecretKeys).toEqual([]);
+  });
+});

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -13,6 +13,35 @@ import type { Db } from "@carsonos/db";
 import { instanceSettings, households } from "@carsonos/db";
 import { isHydratableEnvKey } from "../services/env-hydration.js";
 
+export const SECRET_SETTING_KEYS = ["ANTHROPIC_API_KEY", "GROQ_API_KEY"] as const;
+
+export function isSecretSettingKey(key: string): boolean {
+  return (SECRET_SETTING_KEYS as readonly string[]).includes(key);
+}
+
+export function publicSettingsFromRows(
+  rows: Array<{ key: string; value: unknown }>,
+): { settings: Record<string, unknown>; savedSecretKeys: string[] } {
+  const settings: Record<string, unknown> = {};
+  const savedSecretKeys: string[] = [];
+
+  for (const row of rows) {
+    if (isSecretSettingKey(row.key) && typeof row.value === "string" && row.value.length > 0) {
+      settings[row.key] = "";
+      savedSecretKeys.push(row.key);
+      continue;
+    }
+
+    settings[row.key] = row.value;
+  }
+
+  return { settings, savedSecretKeys };
+}
+
+function publicSettingsFromEntries(entries: Array<[string, unknown]>) {
+  return publicSettingsFromRows(entries.map(([key, value]) => ({ key, value })));
+}
+
 export function createSettingsRoutes(db: Db): Router {
   const router = Router();
 
@@ -20,11 +49,7 @@ export function createSettingsRoutes(db: Db): Router {
   // Augments instance settings with household data as fallbacks
   router.get("/", async (_req, res) => {
     const rows = await db.select().from(instanceSettings).all();
-
-    const settings: Record<string, unknown> = {};
-    for (const row of rows) {
-      settings[row.key] = row.value;
-    }
+    const { settings, savedSecretKeys } = publicSettingsFromRows(rows);
 
     // Include household name and timezone if not overridden in instance settings
     if (!settings["HOUSEHOLD_NAME"] || !settings["TIMEZONE"]) {
@@ -35,7 +60,7 @@ export function createSettingsRoutes(db: Db): Router {
       }
     }
 
-    res.json({ settings });
+    res.json({ settings, savedSecretKeys });
   });
 
   // PUT /:key -- update a single setting
@@ -96,7 +121,7 @@ export function createSettingsRoutes(db: Db): Router {
         console.log(`[settings] ${key} cleared from process.env`);
       }
     }
-    res.json({ settings: { [key]: value } });
+    res.json(publicSettingsFromEntries([[key, value]]));
   });
 
   // PUT / -- bulk update settings
@@ -133,7 +158,7 @@ export function createSettingsRoutes(db: Db): Router {
       results[key] = value;
     }
 
-    res.json({ settings: results });
+    res.json(publicSettingsFromEntries(Object.entries(results)));
   });
 
   // GET /validate-path?path=... -- check if a directory exists on disk

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -155,6 +155,21 @@ export function createSettingsRoutes(db: Db): Router {
         });
       }
 
+      // Same env-hydration as the single-key PUT path: a deliberate UI
+      // save should take effect in the running process immediately.
+      // Without this, a bulk-saved GROQ_API_KEY would write to the DB
+      // but voice transcription wouldn't pick it up until the next
+      // server restart. (Review fix: Claude I1, 2026-05-02.)
+      if (isHydratableEnvKey(key)) {
+        if (typeof value === "string" && value.length > 0) {
+          process.env[key] = value;
+          console.log(`[settings] ${key} updated and applied to process.env`);
+        } else {
+          delete process.env[key];
+          console.log(`[settings] ${key} cleared from process.env`);
+        }
+      }
+
       results[key] = value;
     }
 

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -20,6 +20,9 @@ import {
   Save,
   Check,
   Mic,
+  Pencil,
+  Trash2,
+  RotateCcw,
 } from "lucide-react";
 
 // ── Types ──────────────────────────────────────────────────────────
@@ -28,7 +31,13 @@ interface SettingsMap {
   [key: string]: string;
 }
 
+interface SettingsResponse {
+  settings: SettingsMap;
+  savedSecretKeys?: string[];
+}
+
 type AdapterType = "claude-code" | "codex" | "anthropic-sdk";
+type SecretSettingKey = "ANTHROPIC_API_KEY" | "GROQ_API_KEY";
 
 // ── Constants ──────────────────────────────────────────────────────
 
@@ -89,39 +98,162 @@ function PasswordField({
   value,
   onChange,
   placeholder,
+  hasSavedValue = false,
+  isDirty = false,
+  onClearSaved,
+  onCancelChange,
 }: {
   label: string;
   value: string;
   onChange: (v: string) => void;
   placeholder?: string;
+  hasSavedValue?: boolean;
+  isDirty?: boolean;
+  onClearSaved?: () => void;
+  onCancelChange?: () => void;
 }) {
   const [visible, setVisible] = useState(false);
+  const [replacing, setReplacing] = useState(false);
+  const canReveal = value.length > 0;
+  const showSavedState = hasSavedValue && !isDirty && !replacing;
+  const markedForClear = hasSavedValue && isDirty && value.length === 0;
+  const showInput = !showSavedState && !markedForClear;
+
+  const cancelChange = () => {
+    setVisible(false);
+    setReplacing(false);
+    onCancelChange?.();
+  };
 
   return (
     <div>
-      <label className="text-xs font-medium block mb-1.5" style={{ color: "#5a5a5a" }}>
-        {label}
-      </label>
-      <div className="flex items-center gap-2">
-        <div className="relative flex-1">
-          <Input
-            type={visible ? "text" : "password"}
-            value={value}
-            onChange={(e) => onChange(e.target.value)}
-            placeholder={placeholder}
-            className="pr-9"
-            style={{ borderColor: "#ddd5c8" }}
-          />
-          <button
-            type="button"
-            onClick={() => setVisible(!visible)}
-            className="absolute right-2.5 top-1/2 -translate-y-1/2"
-            style={{ color: "#8a8070" }}
-          >
-            {visible ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-          </button>
-        </div>
+      <div className="flex items-center justify-between gap-2 mb-1.5">
+        <label className="text-xs font-medium" style={{ color: "#5a5a5a" }}>
+          {label}
+        </label>
+        {showSavedState && (
+          <span className="inline-flex items-center gap-1 text-[11px]" style={{ color: "#2e7d32" }}>
+            <Check className="h-3 w-3" /> Saved
+          </span>
+        )}
       </div>
+
+      {showSavedState && (
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <div
+            className="h-9 flex-1 rounded-md border px-3 flex items-center justify-between"
+            style={{ borderColor: "#ddd5c8", background: "#faf8f4" }}
+          >
+            <span className="text-sm tracking-[0.18em]" style={{ color: "#8a8070" }}>
+              •••• •••• ••••
+            </span>
+            <span className="text-[11px]" style={{ color: "#7a7060" }}>
+              hidden
+            </span>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-9 text-xs"
+              style={{ borderColor: "#ddd5c8" }}
+              onClick={() => setReplacing(true)}
+            >
+              <Pencil className="h-3.5 w-3.5 mr-1" /> Replace
+            </Button>
+            {onClearSaved && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-9 text-xs"
+                style={{ borderColor: "#ead2c8", color: "#8a3a28" }}
+                onClick={() => {
+                  setVisible(false);
+                  setReplacing(false);
+                  onClearSaved();
+                }}
+              >
+                <Trash2 className="h-3.5 w-3.5 mr-1" /> Clear
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {markedForClear && (
+        <div
+          className="rounded-md border px-3 py-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+          style={{ borderColor: "#ead2c8", background: "#fff8f5" }}
+        >
+          <div>
+            <p className="text-xs font-medium" style={{ color: "#8a3a28" }}>
+              Saved key will be cleared when you save changes.
+            </p>
+            <p className="text-[11px]" style={{ color: "#9a6b5e" }}>
+              The current key remains active until Save.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 text-xs self-start sm:self-auto"
+            style={{ borderColor: "#ead2c8" }}
+            onClick={cancelChange}
+          >
+            <RotateCcw className="h-3.5 w-3.5 mr-1" /> Undo
+          </Button>
+        </div>
+      )}
+
+      {showInput && (
+        <div>
+          <div className="flex items-center gap-2">
+            <div className="relative flex-1">
+              <Input
+                type={visible ? "text" : "password"}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                placeholder={hasSavedValue ? "Paste replacement key" : placeholder}
+                className="pr-9"
+                style={{ borderColor: "#ddd5c8" }}
+                autoComplete="new-password"
+                spellCheck={false}
+              />
+              {canReveal && (
+                <button
+                  type="button"
+                  onClick={() => setVisible(!visible)}
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2"
+                  style={{ color: "#8a8070" }}
+                  aria-label={visible ? "Hide value" : "Show value"}
+                >
+                  {visible ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+                </button>
+              )}
+            </div>
+            {hasSavedValue && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-9 text-xs"
+                style={{ borderColor: "#ddd5c8" }}
+                onClick={cancelChange}
+              >
+                Cancel
+              </Button>
+            )}
+          </div>
+          {hasSavedValue && (
+            <p className="text-[11px] mt-1.5" style={{ color: "#7a7060" }}>
+              Saving will replace the saved key. The current key remains active until Save.
+            </p>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -168,13 +300,14 @@ export function SettingsPage() {
   const [dirty, setDirty] = useState<Record<string, string>>({});
   const [saved, setSaved] = useState<Record<string, boolean>>({});
 
-  const { data: settings, isLoading } = useQuery<SettingsMap>({
+  const { data: settingsResponse, isLoading } = useQuery<SettingsResponse>({
     queryKey: ["settings"],
     queryFn: async () => {
-      const res = await api.get<{ settings: SettingsMap }>("/settings");
-      return res.settings;
+      return api.get<SettingsResponse>("/settings");
     },
   });
+  const settings = settingsResponse?.settings;
+  const savedSecretKeys = new Set(settingsResponse?.savedSecretKeys ?? []);
 
   const updateSetting = useMutation({
     mutationFn: ({ key, value }: { key: string; value: string }) =>
@@ -205,6 +338,21 @@ export function SettingsPage() {
   const setVal = (key: string, value: string) => {
     setDirty((prev) => ({ ...prev, [key]: value }));
   };
+
+  const resetVal = (key: string) => {
+    setDirty((prev) => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  };
+
+  const secretVal = (key: SecretSettingKey): string => {
+    if (key in dirty) return dirty[key];
+    return "";
+  };
+
+  const hasSavedSecret = (key: SecretSettingKey): boolean => savedSecretKeys.has(key);
 
   const saveKey = (key: string) => {
     if (key in dirty) {
@@ -292,9 +440,13 @@ export function SettingsPage() {
         {showApiKey && (
           <PasswordField
             label="ANTHROPIC_API_KEY"
-            value={val("ANTHROPIC_API_KEY")}
+            value={secretVal("ANTHROPIC_API_KEY")}
             onChange={(v) => setVal("ANTHROPIC_API_KEY", v)}
             placeholder="sk-ant-..."
+            hasSavedValue={hasSavedSecret("ANTHROPIC_API_KEY")}
+            isDirty={"ANTHROPIC_API_KEY" in dirty}
+            onClearSaved={() => setVal("ANTHROPIC_API_KEY", "")}
+            onCancelChange={() => resetVal("ANTHROPIC_API_KEY")}
           />
         )}
 
@@ -361,9 +513,13 @@ export function SettingsPage() {
       <SettingSection title="Voice & Media" icon={Mic}>
         <PasswordField
           label="GROQ_API_KEY"
-          value={val("GROQ_API_KEY")}
+          value={secretVal("GROQ_API_KEY")}
           onChange={(v) => setVal("GROQ_API_KEY", v)}
           placeholder="gsk_..."
+          hasSavedValue={hasSavedSecret("GROQ_API_KEY")}
+          isDirty={"GROQ_API_KEY" in dirty}
+          onClearSaved={() => setVal("GROQ_API_KEY", "")}
+          onCancelChange={() => resetVal("GROQ_API_KEY")}
         />
         <p className="text-xs" style={{ color: "#7a7060" }}>
           Used by Groq Whisper to transcribe voice messages and audio

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import { Card, CardContent } from "@/components/ui/card";
@@ -114,6 +114,22 @@ function PasswordField({
 }) {
   const [visible, setVisible] = useState(false);
   const [replacing, setReplacing] = useState(false);
+
+  // Reset the "replacing" flag when the parent clears `dirty` after a
+  // successful save (isDirty transitions from true to false). Without
+  // this, the field would stay stuck in replacement mode after Save —
+  // showing an empty input and the "will replace saved key" warning
+  // even though the new key is already saved. (Review fix: Codex P3,
+  // 2026-05-02.)
+  const prevIsDirtyRef = useRef(isDirty);
+  useEffect(() => {
+    if (prevIsDirtyRef.current && !isDirty && replacing) {
+      setReplacing(false);
+      setVisible(false);
+    }
+    prevIsDirtyRef.current = isDirty;
+  }, [isDirty, replacing]);
+
   const canReveal = value.length > 0;
   const showSavedState = hasSavedValue && !isDirty && !replacing;
   const markedForClear = hasSavedValue && isDirty && value.length === 0;


### PR DESCRIPTION
## Summary

Closes #47.

- Stops `/api/settings` from returning saved values for Settings-managed secrets (`GROQ_API_KEY`, `ANTHROPIC_API_KEY`) on read and write responses.
- Returns secret presence metadata through `savedSecretKeys` so the UI can show a saved state without hydrating the secret into the DOM.
- Updates Settings password fields to stay empty for saved secrets, show `Saved` / `Replace saved key`, and only allow reveal for newly typed replacement values.

## Notes

This follows the OpenClaw-style SecretRef/dashboard pattern: saved credentials are represented by metadata or references in the UI, while resolved secret values stay out of browser fields and response payloads.

## Validation

- `pnpm --filter @carsonos/server test -- settings`
- `pnpm --filter @carsonos/ui typecheck`
- `pnpm --filter @carsonos/server typecheck`
- `pnpm --filter @carsonos/ui build`