### PR TITLE
fix: hasProfile honors disk-based USER.md, not just DB column

### DIFF
--- a/server/src/services/__tests__/constitution-engine-has-profile.test.ts
+++ b/server/src/services/__tests__/constitution-engine-has-profile.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { computeHasProfile } from "../constitution-engine.js";
+
+describe("computeHasProfile", () => {
+  it("returns false when both sources are null", () => {
+    expect(computeHasProfile(null, null)).toBe(false);
+  });
+
+  it("returns false when both sources are undefined", () => {
+    expect(computeHasProfile(undefined, undefined)).toBe(false);
+  });
+
+  it("returns false when both sources are empty strings", () => {
+    expect(computeHasProfile("", "")).toBe(false);
+  });
+
+  it("returns false when both sources contain only whitespace", () => {
+    expect(computeHasProfile("   \n\t  ", "  \n  ")).toBe(false);
+  });
+
+  it("returns true when only the legacy DB column has content", () => {
+    expect(computeHasProfile(null, "Grant is 17 and loves music.")).toBe(true);
+  });
+
+  // Regression test for the bug where firstContact was incorrectly true
+  // when the profile lived only on disk (USER.md, the v0.5 preference).
+  it("returns true when only the disk-based USER.md has content (profileContent is null)", () => {
+    const userMd = "# Grant\n\nGrant is a high-school junior who plays guitar.\n";
+    expect(computeHasProfile(userMd, null)).toBe(true);
+  });
+
+  it("returns true when only the disk-based USER.md has content (profileContent is empty string)", () => {
+    const userMd = "# Grant\n\nGrant is a high-school junior who plays guitar.\n";
+    expect(computeHasProfile(userMd, "")).toBe(true);
+  });
+
+  it("returns true when both sources have content", () => {
+    expect(computeHasProfile("# Grant\n\ndisk profile", "db profile")).toBe(true);
+  });
+
+  it("isFirstContact derivation: disk-only profile + non-parent role yields firstContact=false", () => {
+    // Mirrors the engine's derivation:
+    //   const hasProfile = computeHasProfile(userMd, profileContent);
+    //   const isFirstContact = !hasProfile && member.role !== "parent";
+    const userMdContent = "# Elsie\n\nElsie is 9 and loves horses.\n";
+    const profileContent: string | null = null;
+    const role: string = "child";
+
+    const hasProfile = computeHasProfile(userMdContent, profileContent);
+    const isFirstContact = !hasProfile && role !== "parent";
+
+    expect(hasProfile).toBe(true);
+    expect(isFirstContact).toBe(false);
+  });
+
+  it("isFirstContact derivation: empty disk + empty DB + non-parent role yields firstContact=true", () => {
+    const role: string = "child";
+    const hasProfile = computeHasProfile(null, null);
+    const isFirstContact = !hasProfile && role !== "parent";
+
+    expect(hasProfile).toBe(false);
+    expect(isFirstContact).toBe(true);
+  });
+});

--- a/server/src/services/constitution-engine.ts
+++ b/server/src/services/constitution-engine.ts
@@ -294,6 +294,20 @@ function leanResumeEnabled(): boolean {
   return process.env.CARSONOS_LEAN_RESUME === "true";
 }
 
+/**
+ * Decide whether a member has a usable profile. v0.5+ stores the profile
+ * on disk as USER.md; the legacy `family_members.profile_content` DB column
+ * remains as a fallback during the transition window. Either source counts.
+ *
+ * Returns true if either input contains non-whitespace content.
+ */
+export function computeHasProfile(
+  userMdContent: string | null | undefined,
+  profileContent: string | null | undefined,
+): boolean {
+  return !!(userMdContent?.trim() || profileContent?.trim());
+}
+
 export class ConstitutionEngine {
   private cache = new Map<string, CachedConstitution>();
   private cachedMemorySchema: string | null = null;
@@ -572,8 +586,15 @@ export class ConstitutionEngine {
       : await this.getConversationHistory(conversationId);
     perf.historyMs = Date.now() - historyStart;
 
-    // Detect first-contact onboarding: no profile + member is not a parent
-    const hasProfile = !!(member.profileContent && member.profileContent.trim());
+    // Detect first-contact onboarding: no profile + member is not a parent.
+    // hasProfile must consider both the disk-based USER.md (v0.5+ preference)
+    // and the legacy DB column. Without the disk check, agents whose profile
+    // lives only on disk would incorrectly trigger first-contact onboarding.
+    const memberSlugForProfile = slugifyName(member.name);
+    const userMdForProfile = this.dataDir
+      ? loadUserMd(this.dataDir, memberSlugForProfile)
+      : null;
+    const hasProfile = computeHasProfile(userMdForProfile, member.profileContent);
     const assistantTurnCount = history.filter((m) => m.role === "assistant").length;
     const isFirstContact = !hasProfile && member.role !== "parent";
 
@@ -601,9 +622,9 @@ export class ConstitutionEngine {
     // Prefer USER.md / PERSONALITY.md from disk; fall back to DB columns
     // during the v0.5.0 transition window. v0.5.x will deprecate the
     // DB columns once all instances have been migrated.
-    const memberSlug = slugifyName(member.name);
+    const memberSlug = memberSlugForProfile;
     const agentSlug = slugifyName(agent.name);
-    const userMdContent = this.dataDir ? loadUserMd(this.dataDir, memberSlug) : null;
+    const userMdContent = userMdForProfile;
     const personalityMdContent = this.dataDir ? loadPersonalityMd(this.dataDir, agentSlug) : null;
 
     // Chief-of-Staff-only sections. Determined here so we can decide


### PR DESCRIPTION
## Summary

- `isFirstContact` was incorrectly `true` for members whose profile lived only on disk (USER.md, the v0.5+ preference), because `hasProfile` only checked `member.profileContent` (the legacy DB column). Result: agents greeted established family members with the first-contact onboarding message ("you don't have a profile set up") even though their profile was already being injected into the prompt.
- Fix: compute `hasProfile` from BOTH sources. Extracted a small pure helper `computeHasProfile(userMd, profileContent)` that returns `true` iff either source has non-whitespace content, and switched the engine to use it.
- Cleanup: moved the `loadUserMd` call above the first-contact check so the disk read happens once, and reused that value at the later prompt-compilation step (no duplicate disk read, no behavioral change there).

## Files changed

- `server/src/services/constitution-engine.ts` — new exported `computeHasProfile` helper, `hasProfile` now considers disk USER.md, single load + reuse.
- `server/src/services/__tests__/constitution-engine-has-profile.test.ts` — new file, 10 unit tests covering null/undefined/empty/whitespace inputs, the regression case (disk-only profile, DB null → `firstContact=false`), the legacy DB-only path, the empty-everything path, and the full `isFirstContact` derivation.

## Test plan

- [x] `pnpm typecheck` — passes (all 4 workspaces)
- [x] `pnpm --filter @carsonos/server test` — 481/481 pass, including the 10 new tests
- [x] Verified pre-existing UI test failures (45) reproduce on plain `main` with no changes — unrelated to this PR
- [ ] Manual: in a household where a member has only USER.md on disk and `family_members.profile_content` is `NULL`, confirm the agent does NOT emit the first-contact onboarding message.

## Notes for reviewer

The helper is intentionally tiny and pure so it's testable without standing up the full `ConstitutionEngine`, its DB, adapter, and memory provider. The export does not widen the engine's public surface meaningfully — it's a one-liner predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)