### PR TITLE
fix: invert enrichment routing default to member-slug

### DIFF
--- a/server/src/services/memory/__tests__/enrichment-worker.test.ts
+++ b/server/src/services/memory/__tests__/enrichment-worker.test.ts
@@ -302,6 +302,50 @@ describe("buildExtractionPrompt", () => {
     const { system, user } = __test.buildExtractionPrompt(validPayload);
     expect(system).toMatch(/STRICT JSON/);
     expect(user).toMatch(/Grant got the role/);
-    expect(user).toMatch(/Member: Josh/);
+    expect(user).toMatch(/Member name: Josh/);
+  });
+
+  it("inverts the routing default to member-slug, not household", () => {
+    // Regression for the household-contamination bug: prior wording read
+    // "'household' for facts that affect the family, otherwise the
+    // member-slug" which routed ~73% of personal CarsonOS dev conversations
+    // to `household` instead of `josh`. Default must now be the member slug.
+    const { system, user } = __test.buildExtractionPrompt(validPayload);
+
+    // 1. System prompt states the default explicitly.
+    expect(system).toContain("Default collection: josh");
+
+    // 2. System prompt no longer contains the old, vague wording.
+    expect(system).not.toMatch(/household' for facts that affect the family/);
+
+    // 3. User message exposes the slug so the model can copy it directly.
+    expect(user).toContain("Member slug: josh");
+  });
+
+  it("derives member slug via sanitizeSlug for names with whitespace/case", () => {
+    const { user } = __test.buildExtractionPrompt({
+      ...validPayload,
+      member: "Grant Daws",
+    });
+    expect(user).toContain("Member slug: grant-daws");
+    expect(user).toContain("Default collection: grant-daws");
+  });
+
+  it("includes the pre-filter rules and few-shot examples", () => {
+    const { system } = __test.buildExtractionPrompt(validPayload);
+    expect(system).toMatch(/agent self-description/);
+    expect(system).toMatch(/Agents are not memory entities/);
+    expect(system).toMatch(/Examples:/);
+    expect(system).toMatch(/CarsonOS PR.*collection: "josh"/);
+  });
+});
+
+describe("__test exports", () => {
+  it("still exposes the test surface the rest of the suite relies on", () => {
+    expect(typeof __test.fingerprintPayload).toBe("function");
+    expect(typeof __test.buildExtractionPrompt).toBe("function");
+    expect(typeof __test.extractJsonBlock).toBe("function");
+    expect(__test.AtomCandidateSchema).toBeDefined();
+    expect(__test.ExtractionResponseSchema).toBeDefined();
   });
 });

--- a/server/src/services/memory/enrichment-worker.ts
+++ b/server/src/services/memory/enrichment-worker.ts
@@ -261,15 +261,16 @@ export class EnrichmentWorker {
   }
 
   /**
-   * Existing entity slugs across all collections, refreshed on a 60-second
-   * TTL. Disk-walks all entity-type files via the provider's listEntities,
-   * so the LLM can be given a list of known slugs to reuse instead of
-   * inventing a new one. If the provider doesn't implement listEntities
-   * (non-QMD provider), returns an empty list.
+   * Raw cache of existing entity slugs across all collections, refreshed on a
+   * 60-second TTL. Disk-walks all entity-type files via the provider's
+   * listEntities. If the provider doesn't implement listEntities (non-QMD
+   * provider), returns an empty list.
+   *
+   * NOTE: Returns the list UNSORTED. The member-priority sort + 100-entry cap
+   * lives inside `buildExtractionPrompt` so that callers can't accidentally
+   * skip it and so the sort/cap invariant is self-contained in one place.
    */
-  private getCachedEntityList(
-    memberSlug?: string,
-  ): Array<{ collection: string; slug: string; type: string; title: string }> {
+  private getCachedEntityList(): Array<{ collection: string; slug: string; type: string; title: string }> {
     const ENTITY_LIST_TTL_MS = 60_000;
     const now = Date.now();
     if (this.entityListCache.length === 0 || now - this.entityListCachedAt >= ENTITY_LIST_TTL_MS) {
@@ -279,22 +280,7 @@ export class EnrichmentWorker {
       this.entityListCache = provider.listEntities?.() ?? [];
       this.entityListCachedAt = now;
     }
-    // Return a member-prioritized view so the LLM sees the current member's
-    // entities (and household) first. The 100-entry cap further keeps the
-    // prompt small and prevents household contamination from drowning out
-    // the member's own slugs.
-    if (!memberSlug) return this.entityListCache;
-    const rank = (collection: string): number => {
-      if (collection === memberSlug) return 0;
-      if (collection === "household") return 1;
-      return 2;
-    };
-    return [...this.entityListCache].sort((a, b) => {
-      const ra = rank(a.collection);
-      const rb = rank(b.collection);
-      if (ra !== rb) return ra - rb;
-      return a.collection.localeCompare(b.collection) || a.slug.localeCompare(b.slug);
-    });
+    return this.entityListCache;
   }
 
   /** Has interactive activity been detected within the yield window? */
@@ -380,8 +366,7 @@ export class EnrichmentWorker {
    * the adapter, validate the response, append atoms.
    */
   private async processItem(item: { id: string; payload: EnrichmentTurnPayload }): Promise<void> {
-    const memberSlug = sanitizeSlug(item.payload.member);
-    const prompt = buildExtractionPrompt(item.payload, this.getCachedEntityList(memberSlug));
+    const prompt = buildExtractionPrompt(item.payload, this.getCachedEntityList());
     const result = await this.adapter.execute({
       systemPrompt: prompt.system,
       messages: [{ role: "user", content: prompt.user }],
@@ -598,19 +583,35 @@ function buildExtractionPrompt(
 ): { system: string; user: string } {
   const memberSlug = sanitizeSlug(payload.member);
 
-  // Format the existing-entity list as one entry per line. The caller is
-  // expected to have already sorted the array by member-priority (own
-  // collection first, then household, then others); we preserve that order
-  // here and cap at 100 entries to keep the prompt small and prevent
-  // household contamination from dominating the list.
+  // Format the existing-entity list as one entry per line.
+  //
+  // Own the sort + cap here (rather than relying on the caller) so the
+  // member-priority invariant (own collection → household → other) and the
+  // 100-entry cap are self-contained. Collapsing both into one place avoids
+  // a hidden contract where the caller is silently expected to pre-sort.
   const knownEntitiesBlock = (() => {
     if (existingEntities.length === 0) return "";
+    // Sort: member's own collection first, then household, then others.
+    // Stable secondary sort by collection then slug for deterministic prompts.
+    const rank = (collection: string): number => {
+      if (collection === memberSlug) return 0;
+      if (collection === "household") return 1;
+      return 2;
+    };
+    const sorted = [...existingEntities].sort((a, b) => {
+      const ra = rank(a.collection);
+      const rb = rank(b.collection);
+      if (ra !== rb) return ra - rb;
+      return a.collection.localeCompare(b.collection) || a.slug.localeCompare(b.slug);
+    });
     // Display the date-stripped slug — internal storage prepends YYYY-MM-DD
     // to file ids, but the LLM should see (and emit) the bare slug. Showing
     // the dated form caused the LLM to copy `2026-04-29-claire` verbatim,
     // which `generateMemoryId` then re-date-prefixed to
-    // `2026-04-29-2026-04-29-claire` on save.
-    const capped = existingEntities
+    // `2026-04-29-2026-04-29-claire` on save. The 100-entry cap keeps the
+    // prompt small and prevents household contamination from dominating
+    // the list once the member-own slugs have been promoted to the front.
+    const capped = sorted
       .map((e) => ({ ...e, displaySlug: stripDatePrefix(e.slug) }))
       .slice(0, 100);
     const lines = capped.map(
@@ -643,8 +644,9 @@ function buildExtractionPrompt(
     "- importance: 1-3 trivial, 4-6 normal, 7-9 high signal, 10 corrections only.",
     "",
     "Examples:",
-    "- Josh + Carson discussing a CarsonOS PR → collection: \"josh\"",
-    "- Josh + Carson noting Becca's birthday → collection: \"household\"",
+    "- Josh + Carson discussing a CarsonOS PR → collection: \"josh\", entity_slug: \"carson-os\" (project)",
+    "- Josh + Carson scheduling a family dinner all five members are attending → collection: \"household\"",
+    "- Josh noting Becca's birthday is next week → collection: \"becca\" (atom is about one person)",
     "- Grant + Django working on a song → collection: \"grant\"",
     "- Carson saying \"I am measured and precise\" → {\"atoms\":[]} (agent self-description, no atom)",
     knownEntitiesBlock,

--- a/server/src/services/memory/enrichment-worker.ts
+++ b/server/src/services/memory/enrichment-worker.ts
@@ -267,18 +267,34 @@ export class EnrichmentWorker {
    * inventing a new one. If the provider doesn't implement listEntities
    * (non-QMD provider), returns an empty list.
    */
-  private getCachedEntityList(): Array<{ collection: string; slug: string; type: string; title: string }> {
+  private getCachedEntityList(
+    memberSlug?: string,
+  ): Array<{ collection: string; slug: string; type: string; title: string }> {
     const ENTITY_LIST_TTL_MS = 60_000;
     const now = Date.now();
-    if (this.entityListCache.length > 0 && now - this.entityListCachedAt < ENTITY_LIST_TTL_MS) {
-      return this.entityListCache;
+    if (this.entityListCache.length === 0 || now - this.entityListCachedAt >= ENTITY_LIST_TTL_MS) {
+      const provider = this.memoryProvider as unknown as {
+        listEntities?: () => Array<{ collection: string; slug: string; type: string; title: string }>;
+      };
+      this.entityListCache = provider.listEntities?.() ?? [];
+      this.entityListCachedAt = now;
     }
-    const provider = this.memoryProvider as unknown as {
-      listEntities?: () => Array<{ collection: string; slug: string; type: string; title: string }>;
+    // Return a member-prioritized view so the LLM sees the current member's
+    // entities (and household) first. The 100-entry cap further keeps the
+    // prompt small and prevents household contamination from drowning out
+    // the member's own slugs.
+    if (!memberSlug) return this.entityListCache;
+    const rank = (collection: string): number => {
+      if (collection === memberSlug) return 0;
+      if (collection === "household") return 1;
+      return 2;
     };
-    this.entityListCache = provider.listEntities?.() ?? [];
-    this.entityListCachedAt = now;
-    return this.entityListCache;
+    return [...this.entityListCache].sort((a, b) => {
+      const ra = rank(a.collection);
+      const rb = rank(b.collection);
+      if (ra !== rb) return ra - rb;
+      return a.collection.localeCompare(b.collection) || a.slug.localeCompare(b.slug);
+    });
   }
 
   /** Has interactive activity been detected within the yield window? */
@@ -364,7 +380,8 @@ export class EnrichmentWorker {
    * the adapter, validate the response, append atoms.
    */
   private async processItem(item: { id: string; payload: EnrichmentTurnPayload }): Promise<void> {
-    const prompt = buildExtractionPrompt(item.payload, this.getCachedEntityList());
+    const memberSlug = sanitizeSlug(item.payload.member);
+    const prompt = buildExtractionPrompt(item.payload, this.getCachedEntityList(memberSlug));
     const result = await this.adapter.execute({
       systemPrompt: prompt.system,
       messages: [{ role: "user", content: prompt.user }],
@@ -579,9 +596,13 @@ function buildExtractionPrompt(
   payload: EnrichmentTurnPayload,
   existingEntities: Array<{ collection: string; slug: string; type: string; title: string }> = [],
 ): { system: string; user: string } {
-  // Format the existing-entity list as one entry per line, sorted by
-  // collection then slug for stability. Capped at 200 entries to keep the
-  // prompt under ~5KB even on large families.
+  const memberSlug = sanitizeSlug(payload.member);
+
+  // Format the existing-entity list as one entry per line. The caller is
+  // expected to have already sorted the array by member-priority (own
+  // collection first, then household, then others); we preserve that order
+  // here and cap at 100 entries to keep the prompt small and prevent
+  // household contamination from dominating the list.
   const knownEntitiesBlock = (() => {
     if (existingEntities.length === 0) return "";
     // Display the date-stripped slug — internal storage prepends YYYY-MM-DD
@@ -589,11 +610,10 @@ function buildExtractionPrompt(
     // the dated form caused the LLM to copy `2026-04-29-claire` verbatim,
     // which `generateMemoryId` then re-date-prefixed to
     // `2026-04-29-2026-04-29-claire` on save.
-    const sorted = [...existingEntities]
+    const capped = existingEntities
       .map((e) => ({ ...e, displaySlug: stripDatePrefix(e.slug) }))
-      .sort((a, b) => a.collection.localeCompare(b.collection) || a.displaySlug.localeCompare(b.displaySlug))
-      .slice(0, 200);
-    const lines = sorted.map(
+      .slice(0, 100);
+    const lines = capped.map(
       (e) => `- [${e.collection}] ${e.displaySlug} (${e.type}) — ${e.title}`,
     );
     return [
@@ -611,17 +631,29 @@ function buildExtractionPrompt(
     "Output STRICT JSON matching the schema:",
     `{"atoms":[{"entity_slug":"kebab-case","entity_type":"person|project|place|media|relationship|commitment|goal|concept|fact|preference|event|decision|routine|skill","collection":"household|<member-slug>","content":"<one to three sentences>","importance":<1-10>}]}`,
     "",
+    `This conversation belongs to member slug "${memberSlug}". Default collection: ${memberSlug}.`,
+    "",
     "Rules:",
     "- entity_slug: kebab-case ASCII, no slashes/dots/underscores.",
-    "- collection: 'household' for facts that affect the family, otherwise the member-slug whose memory it belongs to.",
+    `- collection: Default to the member's own slug (\`${memberSlug}\`). Use 'household' ONLY when the atom (a) names two or more household members by name, (b) describes a dated event the whole family attends together, (c) describes a household-wide rule, shared possession, or shared decision, or (d) describes a relationship between two members. When in doubt, use the member slug.`,
     "- content: short, faithful to what was said. Never paraphrase loosely. If exact words matter, use them.",
     "- Don't fabricate. If the turn contains no factual atoms (chitchat, greetings, restating known info), return {\"atoms\":[]}.",
+    "- If the turn is agent self-description (e.g., \"I am patient and formal\"), a system status confirmation (\"memory write succeeded\", \"test complete\"), or contains no durable factual content, return {\"atoms\":[]}.",
+    "- Never create atoms with entity_slug matching the agent's own name (e.g., 'carson', 'django', 'rosie', 'riley'). Agents are not memory entities.",
     "- importance: 1-3 trivial, 4-6 normal, 7-9 high signal, 10 corrections only.",
+    "",
+    "Examples:",
+    "- Josh + Carson discussing a CarsonOS PR → collection: \"josh\"",
+    "- Josh + Carson noting Becca's birthday → collection: \"household\"",
+    "- Grant + Django working on a song → collection: \"grant\"",
+    "- Carson saying \"I am measured and precise\" → {\"atoms\":[]} (agent self-description, no atom)",
     knownEntitiesBlock,
   ].filter(Boolean).join("\n");
 
   const user = [
-    `Member: ${payload.member}`,
+    `Member name: ${payload.member}`,
+    `Member slug: ${memberSlug}`,
+    `Default collection: ${memberSlug}`,
     `Captured at: ${payload.capturedAt}`,
     `Channel: ${payload.channel}`,
     "",


### PR DESCRIPTION
## Summary

- Inverts the enrichment worker's collection-routing rule from "household unless" to "member-slug unless". The Haiku extractor was treating "affects the family" as satisfied by almost any topic, sending ~73% of personal CarsonOS dev conversations into `household` instead of `josh`.
- Routes now default to the member's slug, with `household` only when the atom (a) names ≥2 members, (b) describes a family-wide event, (c) describes a household-wide rule/possession/decision, or (d) describes a relationship between two members.
- Reinforces the rule in three places: a top-line slug declaration, an explicit `Default collection: <slug>` in the user message, and few-shot examples covering personal / household / agent-self-description cases.
- Pre-filter rules added for agent self-description ("I am patient and formal") and system-status confirmations, plus a hard ban on emitting agent names (`carson`, `django`, `rosie`, `riley`) as entity slugs.
- `EXISTING ENTITIES` block now prioritizes the current member's collection (then `household`, then others) and is capped at 100 entries — preventing household contamination from drowning out the member's own slugs and reinforcing the bias the prompt was trying to fix.

## Test plan

- [x] `pnpm -w run test` — full suite green (521 server tests, 50 UI tests, all green)
- [x] `pnpm -r typecheck` — clean
- [x] New regression tests in `enrichment-worker.test.ts` assert:
  - System prompt contains `Default collection: josh`
  - System prompt no longer contains `household' for facts that affect the family`
  - User message contains `Member slug: josh`
  - `sanitizeSlug` is applied for multi-word names (`Grant Daws` → `grant-daws`)
  - The new pre-filter rules and few-shot examples are present
  - `__test` exports still expose the full surface used by the rest of the suite
- [ ] After merge: monitor a day or two of enrichment logs to confirm the personal/household split shifts back toward member collections.

## Files

- `server/src/services/memory/enrichment-worker.ts` — prompt rewrite, member-prioritized `getCachedEntityList`, and `processItem` now passes the slug through.
- `server/src/services/memory/__tests__/enrichment-worker.test.ts` — updated the existing assertion to match the new user-message format and added regression coverage.