### PR TITLE
fix: gmail_read body + From/To rendering for Gmail API payload shape

### DIFF
--- a/server/src/services/google/__tests__/gmail-tools.test.ts
+++ b/server/src/services/google/__tests__/gmail-tools.test.ts
@@ -7,6 +7,7 @@ import {
   formatAddress,
   decodeBase64Url,
   collectPayloadBodies,
+  readPayloadHeader,
 } from "../gmail-tools.js";
 import type { GoogleCalendarProvider } from "../calendar-provider.js";
 
@@ -342,6 +343,19 @@ describe("decodeBase64Url", () => {
   it("returns empty string for empty input", () => {
     expect(decodeBase64Url("")).toBe("");
   });
+
+  it("returns empty string for non-base64url input rather than garbled text", () => {
+    // `Buffer.from(..., "base64")` silently strips invalid chars and produces
+    // mojibake; we want a clean empty string instead.
+    expect(decodeBase64Url("not valid base64!@#")).toBe("");
+    expect(decodeBase64Url("plain english sentence")).toBe("");
+    expect(decodeBase64Url("contains\nnewlines")).toBe("");
+  });
+
+  it("accepts trailing `=` padding", () => {
+    expect(decodeBase64Url("SGVsbG8=")).toBe("Hello");
+    expect(decodeBase64Url("SGk=")).toBe("Hi");
+  });
 });
 
 describe("collectPayloadBodies", () => {
@@ -415,6 +429,128 @@ describe("collectPayloadBodies", () => {
     };
     expect(collectPayloadBodies(payload).plain).toBe("Body");
     expect(collectPayloadBodies(payload).html).toBe("");
+  });
+
+  it("ignores text/plain parts marked Content-Disposition: attachment", () => {
+    // The bug: an attachment ordered BEFORE the real body would shadow it
+    // because both are mimeType text/plain.
+    const payload = {
+      mimeType: "multipart/mixed",
+      parts: [
+        {
+          mimeType: "text/plain",
+          filename: "notes.txt",
+          headers: [
+            { name: "Content-Disposition", value: 'attachment; filename="notes.txt"' },
+          ],
+          body: { data: b64("ATTACHED FILE CONTENT — should not win") },
+        },
+        {
+          mimeType: "text/plain",
+          body: { data: b64("Real body text.") },
+        },
+      ],
+    };
+    expect(collectPayloadBodies(payload)).toEqual({
+      plain: "Real body text.",
+      html: "",
+    });
+  });
+
+  it("ignores text/plain attachments detected by filename alone (no header)", () => {
+    const payload = {
+      mimeType: "multipart/mixed",
+      parts: [
+        {
+          mimeType: "text/plain",
+          filename: "log.txt",
+          body: { data: b64("log content") },
+        },
+        {
+          mimeType: "text/plain",
+          body: { data: b64("Body") },
+        },
+      ],
+    };
+    expect(collectPayloadBodies(payload).plain).toBe("Body");
+  });
+
+  it("matches text/plain even with charset parameter", () => {
+    const payload = {
+      mimeType: "text/plain; charset=utf-8",
+      body: { data: b64("Charset-tagged body") },
+    };
+    expect(collectPayloadBodies(payload)).toEqual({
+      plain: "Charset-tagged body",
+      html: "",
+    });
+  });
+
+  it("matches text/html with charset parameter", () => {
+    const payload = {
+      mimeType: "text/html; charset=ISO-8859-1",
+      body: { data: b64("<p>Charset-tagged html</p>") },
+    };
+    expect(collectPayloadBodies(payload)).toEqual({
+      plain: "",
+      html: "<p>Charset-tagged html</p>",
+    });
+  });
+
+  it("caps recursion depth (pathological deeply-nested payload)", () => {
+    // Build a part nested 25 levels deep with text at the leaf. Past depth 10
+    // the walker should bail rather than blow the stack or chew CPU.
+    let leaf: Record<string, unknown> = {
+      mimeType: "text/plain",
+      body: { data: b64("buried treasure") },
+    };
+    for (let i = 0; i < 25; i++) {
+      leaf = { mimeType: "multipart/mixed", parts: [leaf] };
+    }
+    // Should not throw and should not find the leaf body.
+    const result = collectPayloadBodies(leaf);
+    expect(result.plain).toBe("");
+    expect(result.html).toBe("");
+  });
+
+  it("still reaches a leaf within the depth cap (sanity)", () => {
+    // 5 levels of nesting — well under the cap, body should be found.
+    let leaf: Record<string, unknown> = {
+      mimeType: "text/plain",
+      body: { data: b64("found me") },
+    };
+    for (let i = 0; i < 5; i++) {
+      leaf = { mimeType: "multipart/mixed", parts: [leaf] };
+    }
+    expect(collectPayloadBodies(leaf).plain).toBe("found me");
+  });
+});
+
+describe("readPayloadHeader", () => {
+  it("returns empty string when payload is missing or shaped wrong", () => {
+    expect(readPayloadHeader(null, "From")).toBe("");
+    expect(readPayloadHeader(undefined, "From")).toBe("");
+    expect(readPayloadHeader({}, "From")).toBe("");
+    expect(readPayloadHeader({ headers: "not-an-array" }, "From")).toBe("");
+  });
+
+  it("reads a header value (case-insensitive on name)", () => {
+    const payload = {
+      headers: [
+        { name: "From", value: "Bob <bob@example.com>" },
+        { name: "To", value: "josh@example.com" },
+        { name: "Subject", value: "Hi" },
+      ],
+    };
+    expect(readPayloadHeader(payload, "From")).toBe("Bob <bob@example.com>");
+    expect(readPayloadHeader(payload, "from")).toBe("Bob <bob@example.com>");
+    expect(readPayloadHeader(payload, "TO")).toBe("josh@example.com");
+    expect(readPayloadHeader(payload, "Subject")).toBe("Hi");
+  });
+
+  it("returns empty string when header is absent", () => {
+    const payload = { headers: [{ name: "From", value: "x@y.test" }] };
+    expect(readPayloadHeader(payload, "Cc")).toBe("");
   });
 });
 
@@ -554,6 +690,39 @@ describe("gmail_read handler — From/To rendering", () => {
     expect(result.content).toContain("To: josh@example.com");
   });
 
+  it("falls back to payload.headers[] when top-level header fields are missing", async () => {
+    // Pure Gmail API payload shape: From/To/Subject/Date live only inside
+    // payload.headers[]. The `gws` CLI used to flatten these onto the top
+    // level; if it stops, gmail_read must still render them.
+    const b64 = (s: string) =>
+      Buffer.from(s, "utf8").toString("base64").replace(/\+/g, "-").replace(/\//g, "_");
+    const { provider } = stubProvider([
+      JSON.stringify({
+        id: "abc",
+        payload: {
+          headers: [
+            { name: "From", value: "Tyler <tyler@example.com>" },
+            { name: "To", value: "josh@example.com" },
+            { name: "Cc", value: "coach@example.com" },
+            { name: "Subject", value: "Saturday game" },
+            { name: "Date", value: "Mon, 13 May 2026 10:00:00 -0700" },
+          ],
+          mimeType: "text/plain",
+          body: { data: b64("See you at 9am.") },
+        },
+      }),
+    ]);
+    const handler = createGmailToolHandler(provider, "josh");
+    const result = await handler("gmail_read", { id: "abc" });
+    expect(result.is_error).toBeFalsy();
+    expect(result.content).toContain("From: Tyler <tyler@example.com>");
+    expect(result.content).toContain("To: josh@example.com");
+    expect(result.content).toContain("Cc: coach@example.com");
+    expect(result.content).toContain("Subject: Saturday game");
+    expect(result.content).toContain("Date: Mon, 13 May 2026 10:00:00 -0700");
+    expect(result.content).toContain("See you at 9am.");
+  });
+
   it("reads body from Gmail API native payload.parts shape", async () => {
     const b64 = (s: string) =>
       Buffer.from(s, "utf8").toString("base64").replace(/\+/g, "-").replace(/\//g, "_");
@@ -674,5 +843,107 @@ describe("gmail_read handler — re-fetch fallback", () => {
     expect(result.is_error).toBeFalsy();
     expect(result.content).toContain("(empty — could not retrieve message body)");
     expect(calls).toHaveLength(2);
+  });
+});
+
+describe("gmail_reply handler — defensive coercion of original message", () => {
+  function stubProvider(
+    responses: Array<string | (() => string)>,
+  ): { provider: GoogleCalendarProvider; calls: string[][] } {
+    const calls: string[][] = [];
+    let i = 0;
+    const provider = {
+      gws: vi.fn(async (_member: string, args: string[]) => {
+        calls.push(args);
+        const r = responses[i++];
+        if (typeof r === "function") return r();
+        if (r === undefined) throw new Error("no more stub responses");
+        return r;
+      }),
+    } as unknown as GoogleCalendarProvider;
+    return { provider, calls };
+  }
+
+  it("reads object-shaped From through formatAddress, not raw interpolation", async () => {
+    const { provider, calls } = stubProvider([
+      // First call: read original
+      JSON.stringify({
+        from: { name: "Tyler Coach", email: "tyler@example.com" },
+        subject: "Saturday game",
+        threadId: "thread-xyz",
+      }),
+      // Second call: create draft
+      JSON.stringify({ id: "draft-1" }),
+    ]);
+    const handler = createGmailToolHandler(provider, "josh");
+    const result = await handler("gmail_reply", {
+      messageId: "abc123",
+      body: "Sounds good, see you at 9.",
+    });
+    expect(result.is_error).toBeFalsy();
+    expect(result.content).toContain("Reply draft created");
+    // The raw MIME the draft was built from must use the formatted address
+    // and the Re: subject — never `[object Object]` or `undefined`.
+    // The --upload temp file path is in args[7] of the create call; we can't
+    // read it back, but we can verify the create call happened and the read
+    // call happened in the right order.
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toContain("+read");
+    expect(calls[1]).toContain("create");
+  });
+
+  it("falls back to payload.headers[] when From/Subject not flattened", async () => {
+    const { provider, calls } = stubProvider([
+      JSON.stringify({
+        threadId: "thread-pure",
+        payload: {
+          headers: [
+            { name: "From", value: "Tyler <tyler@example.com>" },
+            { name: "Subject", value: "Re: Saturday game" },
+          ],
+        },
+      }),
+      JSON.stringify({ id: "draft-2" }),
+    ]);
+    const handler = createGmailToolHandler(provider, "josh");
+    const result = await handler("gmail_reply", {
+      messageId: "abc123",
+      body: "Confirmed.",
+    });
+    expect(result.is_error).toBeFalsy();
+    expect(calls).toHaveLength(2);
+  });
+
+  it("does not crash when subject is missing entirely (no `.startsWith` on undefined)", async () => {
+    const { provider } = stubProvider([
+      JSON.stringify({
+        from: { email: "x@y.test" },
+        // subject intentionally absent
+      }),
+      JSON.stringify({ id: "draft-3" }),
+    ]);
+    const handler = createGmailToolHandler(provider, "josh");
+    const result = await handler("gmail_reply", {
+      messageId: "abc",
+      body: "ok",
+    });
+    expect(result.is_error).toBeFalsy();
+    expect(result.content).toContain("Reply draft created");
+  });
+
+  it("does not crash when subject is non-string (e.g. null)", async () => {
+    const { provider } = stubProvider([
+      JSON.stringify({
+        from: { email: "x@y.test" },
+        subject: null,
+      }),
+      JSON.stringify({ id: "draft-4" }),
+    ]);
+    const handler = createGmailToolHandler(provider, "josh");
+    const result = await handler("gmail_reply", {
+      messageId: "abc",
+      body: "ok",
+    });
+    expect(result.is_error).toBeFalsy();
   });
 });

--- a/server/src/services/google/__tests__/gmail-tools.test.ts
+++ b/server/src/services/google/__tests__/gmail-tools.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi } from "vitest";
-import { htmlToText, looksLikeHtml, pickEmailBody, createGmailToolHandler } from "../gmail-tools.js";
+import {
+  htmlToText,
+  looksLikeHtml,
+  pickEmailBody,
+  createGmailToolHandler,
+  formatAddress,
+  decodeBase64Url,
+  collectPayloadBodies,
+} from "../gmail-tools.js";
 import type { GoogleCalendarProvider } from "../calendar-provider.js";
 
 describe("htmlToText", () => {
@@ -250,6 +258,330 @@ describe("pickEmailBody", () => {
     // The CLI sometimes returns numeric / null fields for missing parts.
     const msg = { text: null, html: undefined, body: 42 };
     expect(pickEmailBody(msg)).toEqual({ text: "", fromHtml: false });
+  });
+});
+
+describe("formatAddress", () => {
+  it("returns empty string for nullish input", () => {
+    expect(formatAddress(null)).toBe("");
+    expect(formatAddress(undefined)).toBe("");
+  });
+
+  it("passes through raw RFC 5322 strings", () => {
+    expect(formatAddress("Bob Smith <bob@example.com>")).toBe(
+      "Bob Smith <bob@example.com>",
+    );
+    expect(formatAddress("bob@example.com")).toBe("bob@example.com");
+  });
+
+  it("renders { name, email } as 'Name <email>'", () => {
+    expect(formatAddress({ name: "Bob Smith", email: "bob@example.com" })).toBe(
+      "Bob Smith <bob@example.com>",
+    );
+  });
+
+  it("falls back to email-only when name is missing", () => {
+    expect(formatAddress({ email: "bob@example.com" })).toBe("bob@example.com");
+    expect(formatAddress({ name: "", email: "bob@example.com" })).toBe(
+      "bob@example.com",
+    );
+  });
+
+  it("falls back to name-only when email is missing", () => {
+    expect(formatAddress({ name: "Bob Smith" })).toBe("Bob Smith");
+  });
+
+  it("accepts `address` as an alias for `email`", () => {
+    expect(formatAddress({ name: "Bob", address: "bob@example.com" })).toBe(
+      "Bob <bob@example.com>",
+    );
+  });
+
+  it("joins arrays with comma separation", () => {
+    expect(
+      formatAddress([
+        { name: "Bob", email: "bob@example.com" },
+        { name: "Carol", email: "carol@example.com" },
+      ]),
+    ).toBe("Bob <bob@example.com>, Carol <carol@example.com>");
+  });
+
+  it("never returns '[object Object]'", () => {
+    // The original bug — string interpolation gave this for object inputs.
+    expect(formatAddress({ name: "Bob", email: "bob@example.com" })).not.toContain(
+      "[object Object]",
+    );
+    expect(formatAddress([{ email: "bob@example.com" }])).not.toContain(
+      "[object Object]",
+    );
+  });
+
+  it("skips empty entries when joining arrays", () => {
+    expect(formatAddress([{ email: "bob@example.com" }, null, { name: "" }])).toBe(
+      "bob@example.com",
+    );
+  });
+});
+
+describe("decodeBase64Url", () => {
+  it("decodes standard base64url content", () => {
+    // "Hello, world!" → base64url
+    expect(decodeBase64Url("SGVsbG8sIHdvcmxkIQ")).toBe("Hello, world!");
+  });
+
+  it("decodes content using `-` and `_` in place of `+` and `/`", () => {
+    // The bytes 0xFB 0xEF 0xFF encode as `++//` in base64 and `--__` in base64url.
+    const original = Buffer.from([0xfb, 0xef, 0xff]).toString("utf8");
+    expect(decodeBase64Url("--__")).toBe(original);
+  });
+
+  it("handles missing padding", () => {
+    expect(decodeBase64Url("SGk")).toBe("Hi"); // standard would be "SGk="
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(decodeBase64Url("")).toBe("");
+  });
+});
+
+describe("collectPayloadBodies", () => {
+  function b64(s: string): string {
+    return Buffer.from(s, "utf8").toString("base64").replace(/\+/g, "-").replace(/\//g, "_");
+  }
+
+  it("returns empty bodies for non-payload input", () => {
+    expect(collectPayloadBodies(null)).toEqual({ plain: "", html: "" });
+    expect(collectPayloadBodies(undefined)).toEqual({ plain: "", html: "" });
+    expect(collectPayloadBodies("not-an-object")).toEqual({ plain: "", html: "" });
+  });
+
+  it("decodes a flat single-part text/plain payload", () => {
+    const payload = {
+      mimeType: "text/plain",
+      body: { data: b64("Hello there.") },
+    };
+    expect(collectPayloadBodies(payload)).toEqual({
+      plain: "Hello there.",
+      html: "",
+    });
+  });
+
+  it("walks multipart/alternative and keeps both plain and html", () => {
+    const payload = {
+      mimeType: "multipart/alternative",
+      body: { size: 0 },
+      parts: [
+        { mimeType: "text/plain", body: { data: b64("Plain version") } },
+        { mimeType: "text/html", body: { data: b64("<p>HTML version</p>") } },
+      ],
+    };
+    expect(collectPayloadBodies(payload)).toEqual({
+      plain: "Plain version",
+      html: "<p>HTML version</p>",
+    });
+  });
+
+  it("recurses into nested multipart parts", () => {
+    const payload = {
+      mimeType: "multipart/mixed",
+      parts: [
+        {
+          mimeType: "multipart/alternative",
+          parts: [
+            { mimeType: "text/plain", body: { data: b64("Nested plain") } },
+            { mimeType: "text/html", body: { data: b64("<p>Nested html</p>") } },
+          ],
+        },
+        // Attachment part — has data but a non-text mimeType. Ignored.
+        {
+          mimeType: "application/pdf",
+          body: { data: b64("fake-pdf-bytes") },
+        },
+      ],
+    };
+    expect(collectPayloadBodies(payload)).toEqual({
+      plain: "Nested plain",
+      html: "<p>Nested html</p>",
+    });
+  });
+
+  it("ignores attachment parts", () => {
+    const payload = {
+      mimeType: "multipart/mixed",
+      parts: [
+        { mimeType: "text/plain", body: { data: b64("Body") } },
+        { mimeType: "image/png", body: { data: b64("PNG-BYTES") } },
+      ],
+    };
+    expect(collectPayloadBodies(payload).plain).toBe("Body");
+    expect(collectPayloadBodies(payload).html).toBe("");
+  });
+});
+
+describe("pickEmailBody — Gmail API native payload shape", () => {
+  function b64(s: string): string {
+    return Buffer.from(s, "utf8").toString("base64").replace(/\+/g, "-").replace(/\//g, "_");
+  }
+
+  it("extracts text from payload.parts when top-level fields are missing", () => {
+    const msg = {
+      subject: "Hi",
+      payload: {
+        mimeType: "multipart/alternative",
+        parts: [
+          { mimeType: "text/plain", body: { data: b64("Real body content.") } },
+          { mimeType: "text/html", body: { data: b64("<p>Real body content.</p>") } },
+        ],
+      },
+    };
+    const { text, fromHtml } = pickEmailBody(msg);
+    expect(text).toBe("Real body content.");
+    expect(fromHtml).toBe(false);
+  });
+
+  it("falls back to text/html part when plain is absent in payload", () => {
+    const msg = {
+      payload: {
+        mimeType: "text/html",
+        body: { data: b64("<h1>Marketing</h1><p>Buy now.</p>") },
+      },
+    };
+    const { text, fromHtml } = pickEmailBody(msg);
+    expect(text).toContain("Marketing");
+    expect(text).toContain("Buy now.");
+    expect(fromHtml).toBe(true);
+  });
+
+  it("uses Gmail snippet as last-resort fallback", () => {
+    const msg = {
+      subject: "Bare",
+      snippet: "Short preview from Gmail API.",
+    };
+    const { text, fromHtml } = pickEmailBody(msg);
+    expect(text).toBe("Short preview from Gmail API.");
+    expect(fromHtml).toBe(false);
+  });
+
+  it("prefers top-level text over payload parts when both present", () => {
+    const msg = {
+      text: "Top-level plain.",
+      payload: {
+        parts: [{ mimeType: "text/plain", body: { data: b64("Payload plain.") } }],
+      },
+    };
+    expect(pickEmailBody(msg)).toEqual({
+      text: "Top-level plain.",
+      fromHtml: false,
+    });
+  });
+
+  it("prefers payload plain over snippet", () => {
+    const msg = {
+      snippet: "snippet preview",
+      payload: {
+        parts: [{ mimeType: "text/plain", body: { data: b64("full body") } }],
+      },
+    };
+    expect(pickEmailBody(msg).text).toBe("full body");
+  });
+});
+
+describe("gmail_read handler — From/To rendering", () => {
+  function stubProvider(
+    responses: Array<string | (() => string)>,
+  ): { provider: GoogleCalendarProvider; calls: string[][] } {
+    const calls: string[][] = [];
+    let i = 0;
+    const provider = {
+      gws: vi.fn(async (_member: string, args: string[]) => {
+        calls.push(args);
+        const r = responses[i++];
+        if (typeof r === "function") return r();
+        if (r === undefined) throw new Error("no more stub responses");
+        return r;
+      }),
+    } as unknown as GoogleCalendarProvider;
+    return { provider, calls };
+  }
+
+  it("renders object-shaped from/to as 'Name <email>', not [object Object]", async () => {
+    const { provider } = stubProvider([
+      JSON.stringify({
+        from: { name: "Tyler Coach", email: "tyler@example.com" },
+        to: { name: "Josh Daws", email: "josh@example.com" },
+        subject: "Saturday game",
+        date: "2026-05-13",
+        text: "See you at 9am.",
+      }),
+    ]);
+    const handler = createGmailToolHandler(provider, "josh");
+    const result = await handler("gmail_read", { id: "abc123" });
+    expect(result.is_error).toBeFalsy();
+    expect(result.content).toContain("From: Tyler Coach <tyler@example.com>");
+    expect(result.content).toContain("To: Josh Daws <josh@example.com>");
+    expect(result.content).not.toContain("[object Object]");
+  });
+
+  it("renders array-of-recipients To header", async () => {
+    const { provider } = stubProvider([
+      JSON.stringify({
+        from: { email: "boss@example.com" },
+        to: [
+          { name: "Alice", email: "alice@example.com" },
+          { name: "Bob", email: "bob@example.com" },
+        ],
+        subject: "Team update",
+        text: "Body.",
+      }),
+    ]);
+    const handler = createGmailToolHandler(provider, "josh");
+    const result = await handler("gmail_read", { id: "abc123" });
+    expect(result.content).toContain("To: Alice <alice@example.com>, Bob <bob@example.com>");
+  });
+
+  it("still handles raw RFC 5322 string headers", async () => {
+    const { provider } = stubProvider([
+      JSON.stringify({
+        from: "Tyler <tyler@example.com>",
+        to: "josh@example.com",
+        subject: "Old shape",
+        text: "Body.",
+      }),
+    ]);
+    const handler = createGmailToolHandler(provider, "josh");
+    const result = await handler("gmail_read", { id: "abc123" });
+    expect(result.content).toContain("From: Tyler <tyler@example.com>");
+    expect(result.content).toContain("To: josh@example.com");
+  });
+
+  it("reads body from Gmail API native payload.parts shape", async () => {
+    const b64 = (s: string) =>
+      Buffer.from(s, "utf8").toString("base64").replace(/\+/g, "-").replace(/\//g, "_");
+    const { provider, calls } = stubProvider([
+      JSON.stringify({
+        from: { name: "Sender", email: "s@example.com" },
+        to: { email: "josh@example.com" },
+        subject: "Real message",
+        date: "2026-05-13",
+        // No top-level text/body/html — only Gmail's native payload tree.
+        payload: {
+          mimeType: "multipart/alternative",
+          parts: [
+            { mimeType: "text/plain", body: { data: b64("This is the body.") } },
+            {
+              mimeType: "text/html",
+              body: { data: b64("<p>This is the body.</p>") },
+            },
+          ],
+        },
+      }),
+    ]);
+    const handler = createGmailToolHandler(provider, "josh");
+    const result = await handler("gmail_read", { id: "abc123" });
+    expect(result.is_error).toBeFalsy();
+    expect(result.content).toContain("This is the body.");
+    // No re-fetch needed — payload had the body.
+    expect(calls).toHaveLength(1);
   });
 });
 

--- a/server/src/services/google/gmail-tools.ts
+++ b/server/src/services/google/gmail-tools.ts
@@ -278,15 +278,74 @@ export function htmlToText(html: string): string {
  * Decode a base64url-encoded string (Gmail API's native encoding for message
  * part bodies). Base64url uses `-` and `_` in place of `+` and `/` and omits
  * trailing `=` padding. We convert to standard base64 before decoding.
+ *
+ * `Buffer.from(s, "base64")` silently drops invalid characters rather than
+ * throwing, which would produce garbled mojibake if the input is not actually
+ * base64url. To avoid surfacing that to the user, we:
+ *
+ *   1. Validate the input is composed only of base64url-safe characters
+ *      (`A-Z a-z 0-9 - _ =`). Anything else → `""`.
+ *   2. Wrap the decode itself in try/catch as a belt-and-suspenders.
  */
 export function decodeBase64Url(data: string): string {
   if (!data) return "";
   try {
+    if (!/^[A-Za-z0-9_\-]*=*$/.test(data)) return "";
     const normalized = data.replace(/-/g, "+").replace(/_/g, "/");
     return Buffer.from(normalized, "base64").toString("utf8");
   } catch {
     return "";
   }
+}
+
+/**
+ * Detect whether a Gmail API payload part is an attachment (versus an inline
+ * body part). An attachment-shaped `text/plain` part ordered before the real
+ * body can otherwise shadow the body and end up displayed instead.
+ *
+ * Two signals — either one wins:
+ *   - `filename` set and non-empty (Gmail API exposes this on every part; only
+ *     attachment parts have it populated).
+ *   - `Content-Disposition: attachment[; …]` header.
+ */
+function isAttachmentPart(node: Record<string, unknown>): boolean {
+  const filename = typeof node.filename === "string" ? node.filename.trim() : "";
+  if (filename) return true;
+  const headers = node.headers;
+  if (Array.isArray(headers)) {
+    for (const h of headers) {
+      if (!h || typeof h !== "object") continue;
+      const ho = h as Record<string, unknown>;
+      const hname = typeof ho.name === "string" ? ho.name.toLowerCase() : "";
+      const hval = typeof ho.value === "string" ? ho.value.trim().toLowerCase() : "";
+      if (hname === "content-disposition" && hval.startsWith("attachment")) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Read a single header value (case-insensitive) from a Gmail API
+ * `payload.headers[]` array. Used as a fallback for From/To/Subject/Date when
+ * the surrounding tooling stops flattening these onto the top-level message
+ * object (pure Gmail API responses keep them only in `payload.headers[]`).
+ */
+export function readPayloadHeader(payload: unknown, name: string): string {
+  if (!payload || typeof payload !== "object") return "";
+  const headers = (payload as Record<string, unknown>).headers;
+  if (!Array.isArray(headers)) return "";
+  const target = name.toLowerCase();
+  for (const h of headers) {
+    if (!h || typeof h !== "object") continue;
+    const ho = h as Record<string, unknown>;
+    const hname = typeof ho.name === "string" ? ho.name.toLowerCase() : "";
+    if (hname === target) {
+      return typeof ho.value === "string" ? ho.value : "";
+    }
+  }
+  return "";
 }
 
 /**
@@ -296,17 +355,33 @@ export function decodeBase64Url(data: string): string {
  * `multipart/mixed` inside `multipart/related`, etc.), so we recurse.
  *
  * Returned strings are already base64url-decoded UTF-8.
+ *
+ * Safety/correctness guards:
+ *   - **Attachment skip**: parts marked with `Content-Disposition: attachment`
+ *     (or carrying a `filename`) are ignored even if their `mimeType` is
+ *     `text/plain` — otherwise a plain-text attachment ordered before the body
+ *     could shadow the real body.
+ *   - **mimeType matching**: uses `startsWith` so `text/plain; charset=utf-8`
+ *     and `text/html; charset=iso-8859-1` both match.
+ *   - **Recursion cap**: bails after `MAX_DEPTH` levels to bound work on
+ *     pathological / malicious payloads.
  */
+const MAX_PAYLOAD_DEPTH = 10;
+
 export function collectPayloadBodies(payload: unknown): {
   plain: string;
   html: string;
 } {
   const out = { plain: "", html: "" };
   if (!payload || typeof payload !== "object") return out;
-  walk(payload as Record<string, unknown>);
+  walk(payload as Record<string, unknown>, 0);
   return out;
 
-  function walk(node: Record<string, unknown>): void {
+  function walk(node: Record<string, unknown>, depth: number): void {
+    if (depth > MAX_PAYLOAD_DEPTH) return;
+    // Skip attachment parts entirely — both their body and their children.
+    if (isAttachmentPart(node)) return;
+
     const mime = typeof node.mimeType === "string" ? node.mimeType.toLowerCase() : "";
     const body = node.body as { data?: unknown } | undefined;
     const data =
@@ -314,8 +389,8 @@ export function collectPayloadBodies(payload: unknown): {
     if (data) {
       const decoded = decodeBase64Url(data);
       if (decoded) {
-        if (mime === "text/plain" && !out.plain) out.plain = decoded;
-        else if (mime === "text/html" && !out.html) out.html = decoded;
+        if (mime.startsWith("text/plain") && !out.plain) out.plain = decoded;
+        else if (mime.startsWith("text/html") && !out.html) out.html = decoded;
         else if (!mime && !out.plain && !looksLikeHtml(decoded)) out.plain = decoded;
         else if (!mime && !out.html && looksLikeHtml(decoded)) out.html = decoded;
       }
@@ -323,7 +398,7 @@ export function collectPayloadBodies(payload: unknown): {
     const parts = node.parts;
     if (Array.isArray(parts)) {
       for (const p of parts) {
-        if (p && typeof p === "object") walk(p as Record<string, unknown>);
+        if (p && typeof p === "object") walk(p as Record<string, unknown>, depth + 1);
       }
     }
   }
@@ -490,14 +565,30 @@ export function createGmailToolHandler(
           const msg = JSON.parse(jsonStart >= 0 ? extractBalancedJson(stdout, jsonStart) : stdout);
 
           const parts: string[] = [];
-          const from = formatAddress(msg.from);
-          const to = formatAddress(msg.to);
-          const cc = formatAddress(msg.cc);
+          // Headers may be flattened onto the top-level message object (the
+          // `gws` CLI does this) or live only inside `payload.headers[]` (pure
+          // Gmail API response shape). Read both, preferring the flattened
+          // form when present.
+          const from =
+            formatAddress(msg.from) ||
+            formatAddress(readPayloadHeader(msg.payload, "From"));
+          const to =
+            formatAddress(msg.to) ||
+            formatAddress(readPayloadHeader(msg.payload, "To"));
+          const cc =
+            formatAddress(msg.cc) ||
+            formatAddress(readPayloadHeader(msg.payload, "Cc"));
+          const subject =
+            (typeof msg.subject === "string" && msg.subject) ||
+            readPayloadHeader(msg.payload, "Subject");
+          const date =
+            (typeof msg.date === "string" && msg.date) ||
+            readPayloadHeader(msg.payload, "Date");
           if (from) parts.push(`From: ${from}`);
           if (to) parts.push(`To: ${to}`);
           if (cc) parts.push(`Cc: ${cc}`);
-          if (msg.subject) parts.push(`Subject: ${msg.subject}`);
-          if (msg.date) parts.push(`Date: ${msg.date}`);
+          if (subject) parts.push(`Subject: ${subject}`);
+          if (date) parts.push(`Date: ${date}`);
           parts.push("");
 
           // Try to extract a body from whatever the CLI returned. Multipart
@@ -577,17 +668,29 @@ export function createGmailToolHandler(
           const readStart = readOut.indexOf("{");
           const original = JSON.parse(readStart >= 0 ? readOut.slice(readStart) : readOut);
 
-          const replyTo = formatAddress(original.from);
-          const subject = original.subject?.startsWith("Re: ")
-            ? original.subject
-            : `Re: ${original.subject ?? ""}`;
+          // Same defensive handling as gmail_read: From may be an object or
+          // array, may live in payload.headers[], and Subject may be missing
+          // or non-string. Coerce everything carefully before stuffing it into
+          // the outgoing draft.
+          const replyTo =
+            formatAddress(original.from) ||
+            formatAddress(readPayloadHeader(original.payload, "From"));
+          const origSubjectRaw =
+            (typeof original.subject === "string" && original.subject) ||
+            readPayloadHeader(original.payload, "Subject") ||
+            "";
+          const subject = origSubjectRaw.startsWith("Re: ")
+            ? origSubjectRaw
+            : `Re: ${origSubjectRaw}`;
+          const threadId =
+            typeof original.threadId === "string" ? original.threadId : undefined;
 
           const raw = buildRawEmail({
             to: replyTo,
             subject,
             body: input.body as string,
             inReplyTo: input.messageId as string,
-            threadId: original.threadId,
+            threadId,
           });
 
           const tmpFile = join(tmpdir(), `carsonos-reply-${Date.now()}.eml`);
@@ -595,7 +698,7 @@ export function createGmailToolHandler(
 
           try {
             const draftJson: Record<string, unknown> = {
-              message: { threadId: original.threadId },
+              message: threadId ? { threadId } : {},
             };
             const args = [
               "gmail", "users", "drafts", "create",

--- a/server/src/services/google/gmail-tools.ts
+++ b/server/src/services/google/gmail-tools.ts
@@ -275,13 +275,73 @@ export function htmlToText(html: string): string {
 }
 
 /**
+ * Decode a base64url-encoded string (Gmail API's native encoding for message
+ * part bodies). Base64url uses `-` and `_` in place of `+` and `/` and omits
+ * trailing `=` padding. We convert to standard base64 before decoding.
+ */
+export function decodeBase64Url(data: string): string {
+  if (!data) return "";
+  try {
+    const normalized = data.replace(/-/g, "+").replace(/_/g, "/");
+    return Buffer.from(normalized, "base64").toString("utf8");
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Walk a Gmail API `payload` tree (or any part within it) and collect the
+ * decoded text/plain and text/html bodies we find. Gmail multipart messages
+ * nest parts arbitrarily deep (`multipart/alternative` inside
+ * `multipart/mixed` inside `multipart/related`, etc.), so we recurse.
+ *
+ * Returned strings are already base64url-decoded UTF-8.
+ */
+export function collectPayloadBodies(payload: unknown): {
+  plain: string;
+  html: string;
+} {
+  const out = { plain: "", html: "" };
+  if (!payload || typeof payload !== "object") return out;
+  walk(payload as Record<string, unknown>);
+  return out;
+
+  function walk(node: Record<string, unknown>): void {
+    const mime = typeof node.mimeType === "string" ? node.mimeType.toLowerCase() : "";
+    const body = node.body as { data?: unknown } | undefined;
+    const data =
+      body && typeof body === "object" && typeof body.data === "string" ? body.data : "";
+    if (data) {
+      const decoded = decodeBase64Url(data);
+      if (decoded) {
+        if (mime === "text/plain" && !out.plain) out.plain = decoded;
+        else if (mime === "text/html" && !out.html) out.html = decoded;
+        else if (!mime && !out.plain && !looksLikeHtml(decoded)) out.plain = decoded;
+        else if (!mime && !out.html && looksLikeHtml(decoded)) out.html = decoded;
+      }
+    }
+    const parts = node.parts;
+    if (Array.isArray(parts)) {
+      for (const p of parts) {
+        if (p && typeof p === "object") walk(p as Record<string, unknown>);
+      }
+    }
+  }
+}
+
+/**
  * Pick the best body content from a Gmail message JSON returned by the `gws`
- * CLI. Handles both shapes we've observed:
+ * CLI. Handles every shape we've observed:
  *
  *   - `{ body: "..." }` — plain text (CLI's default rendering)
  *   - `{ text: "...", html: "..." }` — multipart messages where the CLI exposes
  *     both parts. Prefer plain text per the task spec; fall back to HTML.
  *   - `{ html: "..." }` — HTML-only message returned via `--html`.
+ *   - `{ payload: { parts: [...] } }` — Gmail API's native shape. The CLI
+ *     passes this through when called with `--headers`/`--format json`. Each
+ *     part has a `mimeType` and a base64url-encoded `body.data` blob. We walk
+ *     the part tree, prefer `text/plain`, fall back to `text/html`.
+ *   - `{ snippet: "..." }` — last-resort preview Gmail always returns.
  *
  * Returns the converted plain text plus a flag indicating whether the source
  * was HTML (so the caller can annotate the output).
@@ -290,6 +350,7 @@ export function pickEmailBody(msg: Record<string, unknown>): {
   text: string;
   fromHtml: boolean;
 } {
+  // 1. Top-level string fields the CLI sometimes flattens for us.
   const plain =
     typeof msg.text === "string" && msg.text.trim()
       ? msg.text.trim()
@@ -306,7 +367,63 @@ export function pickEmailBody(msg: Record<string, unknown>): {
       : "";
   if (html) return { text: htmlToText(html), fromHtml: true };
 
+  // 2. Walk Gmail's native `payload.parts[].body.data` tree.
+  const fromParts = collectPayloadBodies(msg.payload);
+  if (fromParts.plain.trim()) {
+    return { text: fromParts.plain.trim(), fromHtml: false };
+  }
+  if (fromParts.html.trim()) {
+    return { text: htmlToText(fromParts.html), fromHtml: true };
+  }
+
+  // 3. Final fallback: Gmail's `snippet` preview (always present in API
+  //    responses; a truncated plain-text excerpt of the first ~200 chars).
+  if (typeof msg.snippet === "string" && msg.snippet.trim()) {
+    return { text: msg.snippet.trim(), fromHtml: false };
+  }
+
   return { text: "", fromHtml: false };
+}
+
+/**
+ * Render a Gmail address header value as a readable "Name <email>" string.
+ * The `gws` CLI returns these as structured objects (`{ name, email }`) or
+ * arrays of objects rather than the raw RFC 5322 string, so naive string
+ * interpolation gives `[object Object]`. We handle:
+ *
+ *   - `"Bob Smith <bob@example.com>"` (raw string) — passed through as-is
+ *   - `{ name: "Bob Smith", email: "bob@example.com" }` → `"Bob Smith <bob@example.com>"`
+ *   - `{ email: "bob@example.com" }` → `"bob@example.com"`
+ *   - `{ name: "Bob Smith" }` → `"Bob Smith"`
+ *   - `{ address: "bob@example.com" }` (alternate key name) — same as `email`
+ *   - `[{...}, {...}]` arrays — joined with `", "`
+ *   - `null`/`undefined`/other primitives — empty string / coerced
+ */
+export function formatAddress(v: unknown): string {
+  if (v == null) return "";
+  if (typeof v === "string") return v.trim();
+  if (Array.isArray(v)) {
+    return v
+      .map(formatAddress)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+      .join(", ");
+  }
+  if (typeof v === "object") {
+    const o = v as Record<string, unknown>;
+    const name = typeof o.name === "string" ? o.name.trim() : "";
+    const email =
+      typeof o.email === "string"
+        ? o.email.trim()
+        : typeof o.address === "string"
+        ? o.address.trim()
+        : "";
+    if (name && email) return `${name} <${email}>`;
+    if (email) return email;
+    if (name) return name;
+    return "";
+  }
+  return String(v);
 }
 
 /**
@@ -353,9 +470,13 @@ export function createGmailToolHandler(
           }
 
           const formatted = messages
-            .map((m: Record<string, string>) =>
-              `- ${m.from ?? "Unknown"}: ${m.subject ?? "(no subject)"} (${m.date ?? ""}) [id: ${m.id ?? ""}]`
-            )
+            .map((m: Record<string, unknown>) => {
+              const from = formatAddress(m.from) || "Unknown";
+              const subject = (typeof m.subject === "string" && m.subject) || "(no subject)";
+              const date = typeof m.date === "string" ? m.date : "";
+              const id = typeof m.id === "string" ? m.id : "";
+              return `- ${from}: ${subject} (${date}) [id: ${id}]`;
+            })
             .join("\n");
 
           return { content: `${messages.length} messages:\n${formatted}` };
@@ -368,9 +489,13 @@ export function createGmailToolHandler(
           const jsonStart = stdout.indexOf("{");
           const msg = JSON.parse(jsonStart >= 0 ? extractBalancedJson(stdout, jsonStart) : stdout);
 
-          const parts = [];
-          if (msg.from) parts.push(`From: ${msg.from}`);
-          if (msg.to) parts.push(`To: ${msg.to}`);
+          const parts: string[] = [];
+          const from = formatAddress(msg.from);
+          const to = formatAddress(msg.to);
+          const cc = formatAddress(msg.cc);
+          if (from) parts.push(`From: ${from}`);
+          if (to) parts.push(`To: ${to}`);
+          if (cc) parts.push(`Cc: ${cc}`);
           if (msg.subject) parts.push(`Subject: ${msg.subject}`);
           if (msg.date) parts.push(`Date: ${msg.date}`);
           parts.push("");
@@ -452,7 +577,7 @@ export function createGmailToolHandler(
           const readStart = readOut.indexOf("{");
           const original = JSON.parse(readStart >= 0 ? readOut.slice(readStart) : readOut);
 
-          const replyTo = original.from ?? "";
+          const replyTo = formatAddress(original.from);
           const subject = original.subject?.startsWith("Re: ")
             ? original.subject
             : `Re: ${original.subject ?? ""}`;


### PR DESCRIPTION
## Summary

Two regressions in `gmail_read` (and incidentally `gmail_triage` / `gmail_search` / `gmail_reply`):

1. **From / To rendered as `[object Object]`** — the `gws` CLI returns header
   values as structured objects (`{ name, email }`) or arrays of them, not raw
   RFC 5322 strings. The old handler interpolated them directly into template
   strings.
2. **Message bodies came back empty** — `pickEmailBody` only checked top-level
   `text` / `body` / `html` fields. The CLI actually passes Gmail's native API
   shape through: `payload.parts[].body.data`, base64url-encoded and
   mimeType-tagged, with arbitrarily nested multipart layers.

## Changes

- New helper `formatAddress(v)` handles strings, `{name,email}` /
  `{name,address}` objects, and arrays — renders as `"Name <email>"`.
- New helper `decodeBase64Url(s)` for Gmail's `-`/`_` variant.
- New helper `collectPayloadBodies(payload)` walks `payload.parts` recursively,
  prefers `text/plain`, falls back to `text/html`, ignores attachment parts.
- `pickEmailBody` now tries: top-level fields → payload tree → `snippet`
  fallback. HTML is routed through the existing `htmlToText`.
- `gmail_read` also surfaces a `Cc:` header when present.
- `gmail_reply` uses `formatAddress` so the reply-to comes out as a real
  address rather than `[object Object]`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 544 server tests pass, 50 UI tests pass
- [x] 29 new unit tests covering: address shapes (string/object/array/null),
  base64url edge cases (`+/_` mapping, missing padding), payload walking
  (flat, multipart/alternative, nested, attachments), `pickEmailBody`
  precedence (top-level > payload > snippet), and the `gmail_read` handler
  end-to-end against the native Gmail API shape.
- [ ] Live verification against test message IDs `19e1e08c28e6bef0`,
  `19e1e18d7cb86ed9`, `19e1e179681c9877` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)