### PR TITLE
feat(custom-tools): per-agent Telegram bot token via ctx.getAgentBotToken()

### DIFF
--- a/server/src/services/custom-tools/executors.ts
+++ b/server/src/services/custom-tools/executors.ts
@@ -17,7 +17,7 @@ import { join } from "node:path";
 import { randomBytes } from "node:crypto";
 import { and, eq } from "drizzle-orm";
 import type { Db } from "@carsonos/db";
-import { toolSecrets } from "@carsonos/db";
+import { toolSecrets, staffAgents } from "@carsonos/db";
 import type { ToolResult, MemoryProvider } from "@carsonos/shared";
 
 import type { HttpConfig, HttpAuth } from "./skill-md.js";
@@ -45,6 +45,10 @@ export function toolError(code: CustomErrorCode, content: string, detail?: strin
 export interface ExecContext {
   db: Db;
   householdId: string;
+  /** ID of the staff agent invoking this tool (used to resolve per-agent
+   * resources like the agent's own Telegram bot token). Optional because
+   * not every call path has an agent (e.g. internal/system invocations). */
+  agentId?: string;
   memberId?: string;
   memberName?: string;
   memoryProvider?: MemoryProvider | null;
@@ -225,6 +229,43 @@ function stripAuthHeaders(
   return out;
 }
 
+/**
+ * Resolve a staff agent's Telegram bot token from the staff_agents table.
+ *
+ * Lookup order:
+ *   1. If agentId is provided, return that agent's `telegram_bot_token`
+ *      (constrained to the current household for safety).
+ *   2. Otherwise, fall back to the household's head-butler agent token.
+ *   3. Return null when neither is configured.
+ *
+ * This helper exists so script handlers can resolve per-agent bot tokens
+ * automatically (e.g. `send_telegram_photo` sending as the calling agent's
+ * own bot identity) without us having to widen the handler sandbox to
+ * include raw `ctx.db` — which was removed deliberately after a prior
+ * cross-tenant exfiltration regression (see CustomToolContext docstring).
+ */
+async function loadAgentBotToken(
+  db: Db,
+  householdId: string,
+  agentId?: string,
+): Promise<string | null> {
+  if (agentId) {
+    const [row] = await db
+      .select({ token: staffAgents.telegramBotToken })
+      .from(staffAgents)
+      .where(and(eq(staffAgents.id, agentId), eq(staffAgents.householdId, householdId)))
+      .limit(1);
+    if (row?.token) return row.token;
+  }
+  // Fallback: the household's head butler usually has the canonical bot token.
+  const [hb] = await db
+    .select({ token: staffAgents.telegramBotToken })
+    .from(staffAgents)
+    .where(and(eq(staffAgents.householdId, householdId), eq(staffAgents.isHeadButler, true)))
+    .limit(1);
+  return hb?.token ?? null;
+}
+
 async function loadSecret(
   db: Db,
   householdId: string,
@@ -330,8 +371,21 @@ export function executePromptTool(body: string, input: Record<string, unknown>):
 export interface CustomToolContext {
   fetch: typeof globalThis.fetch;
   getSecret: (keyName: string) => Promise<string | null>;
+  /** Resolve the calling agent's Telegram bot token from the staff_agents
+   * table (scoped to the current household). Returns the calling agent's own
+   * token when an agentId is available, otherwise falls back to the
+   * household's head-butler token. Returns null when neither is configured.
+   *
+   * This is a scoped helper rather than raw `db` access so handlers can't
+   * exfiltrate cross-household data — see the cross-tenant exfiltration
+   * note above. Handlers should still call `ctx.getSecret('telegram_bot_token')`
+   * as a final fallback for hand-installed tokens. */
+  getAgentBotToken: () => Promise<string | null>;
   memory: MemoryProvider | null;
   householdId: string;
+  /** ID of the staff agent invoking the tool, when known. Useful for
+   * per-agent attribution and routing (e.g. send-as-this-agent flows). */
+  agentId?: string;
   memberId?: string;
   memberName?: string;
   log: (msg: string) => void;
@@ -368,8 +422,10 @@ export async function executeScriptTool(
   const scriptCtx: CustomToolContext = {
     fetch: globalThis.fetch,
     getSecret: (keyName) => loadSecret(ctx.db, ctx.householdId, keyName, ctx.dataDir),
+    getAgentBotToken: () => loadAgentBotToken(ctx.db, ctx.householdId, ctx.agentId),
     memory: ctx.memoryProvider ?? null,
     householdId: ctx.householdId,
+    agentId: ctx.agentId,
     memberId: ctx.memberId,
     memberName: ctx.memberName,
     log: (msg) => console.log(`[custom-tool] ${msg}`),

--- a/server/src/services/custom-tools/executors.ts
+++ b/server/src/services/custom-tools/executors.ts
@@ -250,14 +250,21 @@ async function loadAgentBotToken(
   agentId?: string,
 ): Promise<string | null> {
   if (agentId) {
+    // "Send-as-self or fail": if the caller has an agent identity, we must
+    // resolve THAT agent's bot token. Falling back to the head butler here
+    // would cause a non-head agent (e.g. Django, Grant's agent) to send as
+    // Carson, which is wrong and breaks inline-button routing. If the agent
+    // row exists but has no token, return null and let the handler's
+    // fallback chain (e.g. ctx.getSecret('telegram_bot_token')) decide.
     const [row] = await db
       .select({ token: staffAgents.telegramBotToken })
       .from(staffAgents)
       .where(and(eq(staffAgents.id, agentId), eq(staffAgents.householdId, householdId)))
       .limit(1);
-    if (row?.token) return row.token;
+    return row?.token ?? null;
   }
-  // Fallback: the household's head butler usually has the canonical bot token.
+  // No agent identity on the caller — fall back to the household's head
+  // butler, which usually has the canonical bot token.
   const [hb] = await db
     .select({ token: staffAgents.telegramBotToken })
     .from(staffAgents)

--- a/server/src/services/tool-registry.ts
+++ b/server/src/services/tool-registry.ts
@@ -796,6 +796,7 @@ export class ToolRegistry {
         const execCtx = {
           db: ctx.db,
           householdId: ctx.householdId,
+          agentId: ctx.agentId,
           memberId: ctx.memberId,
           memberName: ctx.memberName,
           memoryProvider: ctx.memoryProvider,


### PR DESCRIPTION
## Summary

Adds a scoped `ctx.getAgentBotToken()` helper to `CustomToolContext` so script tools (notably `send_telegram_photo`) can resolve the **calling agent's own** `telegram_bot_token` from the `staff_agents` table. Wires `agentId` through `ExecContext → CustomToolContext` so the resolver knows which agent is calling, and updates the live `send_telegram_photo` handler (in `~/.carsonos/tools/`) to prefer that helper, with a graceful fallback to the legacy `ctx.getSecret('telegram_bot_token')` path.

Goal: `send_telegram_photo` (and any future per-agent Telegram tool) just works for Carson, Django, Grant's agent, etc. — each sends from its own bot identity automatically, no hand-installed `tool_secrets` rows required.

## Design decision — why a scoped helper, not raw `ctx.db`

The task brief suggested giving the handler raw `ctx.db` access. I intentionally did not do that. Two reasons:

1. **Security architecture.** `ctx.db` was deliberately removed from the script-tool sandbox after a prior cross-tenant exfiltration regression (see the long `TODO-3` docstring above `CustomToolContext` in `executors.ts`). Re-adding raw db would reopen that hole. A narrow, household-scoped `getAgentBotToken()` helper achieves the same goal — every agent uses its own bot identity — without widening the sandbox.
2. **Runtime constraint.** Script handlers are bundled with esbuild `packages: "external"` and dynamic-imported from a `/tmp` path, so a handler-side `import { staffAgents } from '@carsonos/db'` would not resolve at runtime anyway.

Happy to swap in raw `ctx.db` if you'd rather. Calling it out so you can weigh in.

## Changes

- `server/src/services/custom-tools/executors.ts`
  - `ExecContext` gains optional `agentId?: string`
  - `CustomToolContext` gains optional `agentId?: string` + `getAgentBotToken(): Promise<string | null>`
  - New `loadAgentBotToken()` helper queries `staffAgents.telegramBotToken` scoped to `(id = agentId AND householdId = ctx.householdId)`, then falls back to the household's head-butler token, then returns null.
- `server/src/services/tool-registry.ts`
  - Propagates `ctx.agentId` into the constructed `execCtx` when invoking a household-scoped custom tool.
- Live tool update (via `update_custom_tool`, also mirrored in `~/.carsonos/tools/.../send_telegram_photo/handler.ts`):
  - Calls `ctx.getAgentBotToken()` first, then falls back to `ctx.getSecret('telegram_bot_token')` / `'telegram_token'`.
  - Defensively typed so it tolerates running against an older context shape during rollout (the running server still uses the old context until you restart).

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm --filter @carsonos/server test` — 567/567 pass (29 files)
- [x] UI test suite is currently red on `main` (45/50 fail with `React.act is not a function` — React 19 environmental issue, unrelated to this change). Confirmed identical failure shape on `main`.
- [x] Live end-to-end: invoked `send_telegram_photo` against the running server; photo delivered successfully (`message_id=3462`). This exercised the legacy `getSecret` fallback because the running server hasn't picked up the new context shape yet.
- [ ] After merge + server restart: re-test from a non-head agent (Django / Grant's agent) and confirm it sends from that agent's own bot identity, with no `tool_secrets` row required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)