### PR TITLE
fix: route X/Twitter links to the household X-reader tool, not web search

### DIFF
--- a/server/src/services/__tests__/link-tool-routing.test.ts
+++ b/server/src/services/__tests__/link-tool-routing.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+import type { ToolDefinition } from "@carsonos/shared";
+import {
+  detectXPostUrls,
+  hasXPostLink,
+  findXPostTool,
+  buildXLinkSteering,
+  appendSteeringToLastUserMessage,
+} from "../link-tool-routing.js";
+
+// The real household tool that prompted this fix.
+const xGetPost: ToolDefinition = {
+  name: "x_get_post",
+  description:
+    "Fetch a specific X/Twitter post and its thread by URL using Grok's live x_search tool",
+  input_schema: {
+    type: "object",
+    properties: { url: { type: "string", description: "Full X/Twitter post URL" } },
+    required: ["url"],
+  },
+};
+
+const xSearchPosts: ToolDefinition = {
+  name: "x_search_posts",
+  description: "Search recent X/Twitter posts by keyword query",
+  input_schema: {
+    type: "object",
+    properties: { query: { type: "string" } },
+    required: ["query"],
+  },
+};
+
+const unrelatedTool: ToolDefinition = {
+  name: "list_calendar_events",
+  description: "List upcoming calendar events",
+  input_schema: { type: "object", properties: {} },
+};
+
+describe("detectXPostUrls", () => {
+  it("detects the exact URL Josh sent (x.com with ?s= query)", () => {
+    const urls = detectXPostUrls(
+      "check this out https://x.com/pbakaus/status/2060208540992880794?s=46",
+    );
+    expect(urls).toEqual([
+      "https://x.com/pbakaus/status/2060208540992880794?s=46",
+    ]);
+  });
+
+  it("detects twitter.com, mobile, and www variants", () => {
+    expect(detectXPostUrls("https://twitter.com/jack/status/20")).toEqual([
+      "https://twitter.com/jack/status/20",
+    ]);
+    expect(
+      detectXPostUrls("https://mobile.twitter.com/jack/status/20"),
+    ).toEqual(["https://mobile.twitter.com/jack/status/20"]);
+    expect(detectXPostUrls("https://www.x.com/jack/status/20")).toEqual([
+      "https://www.x.com/jack/status/20",
+    ]);
+  });
+
+  it("detects fxtwitter / vxtwitter mirrors", () => {
+    expect(
+      detectXPostUrls("https://fxtwitter.com/user/status/12345"),
+    ).toEqual(["https://fxtwitter.com/user/status/12345"]);
+    expect(
+      detectXPostUrls("https://vxtwitter.com/user/status/12345"),
+    ).toEqual(["https://vxtwitter.com/user/status/12345"]);
+  });
+
+  it("trims trailing punctuation hugging a pasted link", () => {
+    expect(
+      detectXPostUrls("see (https://x.com/a/status/99)."),
+    ).toEqual(["https://x.com/a/status/99"]);
+  });
+
+  it("dedupes repeated links", () => {
+    const text =
+      "https://x.com/a/status/1 and again https://x.com/a/status/1";
+    expect(detectXPostUrls(text)).toEqual(["https://x.com/a/status/1"]);
+  });
+
+  it("returns nothing for profile links or non-X URLs", () => {
+    expect(detectXPostUrls("https://x.com/pbakaus")).toEqual([]);
+    expect(detectXPostUrls("https://example.com/a/status/1")).toEqual([]);
+    expect(detectXPostUrls("just some text")).toEqual([]);
+    expect(detectXPostUrls("")).toEqual([]);
+  });
+
+  it("hasXPostLink mirrors detection", () => {
+    expect(hasXPostLink("https://x.com/a/status/1")).toBe(true);
+    expect(hasXPostLink("no link here")).toBe(false);
+  });
+});
+
+describe("findXPostTool", () => {
+  it("picks x_get_post over x_search_posts", () => {
+    expect(findXPostTool([xSearchPosts, xGetPost])).toBe("x_get_post");
+  });
+
+  it("ignores search-only X tools", () => {
+    expect(findXPostTool([xSearchPosts])).toBeNull();
+  });
+
+  it("returns null when no X reading tool is present", () => {
+    expect(findXPostTool([unrelatedTool])).toBeNull();
+    expect(findXPostTool([])).toBeNull();
+  });
+
+  it("matches a generically-named tool that reads X posts by url", () => {
+    const generic: ToolDefinition = {
+      name: "fetch_tweet",
+      description: "Read a tweet from Twitter given its url",
+      input_schema: { type: "object", properties: { url: { type: "string" } } },
+    };
+    expect(findXPostTool([generic])).toBe("fetch_tweet");
+  });
+
+  it("prefers the url-input tool when multiple X readers exist", () => {
+    const noUrl: ToolDefinition = {
+      name: "x_read_latest",
+      description: "Read the latest X post from an author",
+      input_schema: { type: "object", properties: { handle: { type: "string" } } },
+    };
+    expect(findXPostTool([noUrl, xGetPost])).toBe("x_get_post");
+  });
+});
+
+describe("buildXLinkSteering", () => {
+  it("returns null when there is no X link", () => {
+    expect(buildXLinkSteering("hello there", [xGetPost])).toBeNull();
+  });
+
+  it("names the tool and forbids web search when the tool is available", () => {
+    const note = buildXLinkSteering(
+      "read https://x.com/pbakaus/status/2060208540992880794?s=46",
+      [xGetPost, unrelatedTool],
+    );
+    expect(note).not.toBeNull();
+    expect(note).toContain("x_get_post");
+    expect(note).toContain("https://x.com/pbakaus/status/2060208540992880794?s=46");
+    expect(note!.toLowerCase()).toContain("do not use web search");
+    expect(note!.toLowerCase()).toContain("do not summarize");
+  });
+
+  it("forbids guessing when no X tool is available", () => {
+    const note = buildXLinkSteering(
+      "read https://x.com/a/status/1",
+      [unrelatedTool],
+    );
+    expect(note).not.toBeNull();
+    expect(note).not.toContain("x_get_post");
+    expect(note!.toLowerCase()).toContain("do not guess");
+    expect(note!.toLowerCase()).toContain("can't open the link");
+  });
+});
+
+describe("appendSteeringToLastUserMessage", () => {
+  it("appends to the last user message, leaving others untouched", () => {
+    const msgs = [
+      { role: "user", content: "first" },
+      { role: "assistant", content: "reply" },
+      { role: "user", content: "https://x.com/a/status/1" },
+    ];
+    const note = buildXLinkSteering(msgs[2].content, [xGetPost]);
+    const out = appendSteeringToLastUserMessage(msgs, note);
+    expect(out[0].content).toBe("first");
+    expect(out[1].content).toBe("reply");
+    expect(out[2].content).toContain("https://x.com/a/status/1");
+    expect(out[2].content).toContain("x_get_post");
+  });
+
+  it("is a no-op when the note is null", () => {
+    const msgs = [{ role: "user", content: "hi" }];
+    expect(appendSteeringToLastUserMessage(msgs, null)).toBe(msgs);
+  });
+
+  it("does not mutate the input array", () => {
+    const msgs = [{ role: "user", content: "https://x.com/a/status/1" }];
+    const out = appendSteeringToLastUserMessage(msgs, "NOTE");
+    expect(msgs[0].content).toBe("https://x.com/a/status/1");
+    expect(out[0].content).toContain("NOTE");
+  });
+
+  it("returns the array unchanged when there is no user message", () => {
+    const msgs = [{ role: "assistant", content: "only assistant" }];
+    expect(appendSteeringToLastUserMessage(msgs, "NOTE")).toBe(msgs);
+  });
+});

--- a/server/src/services/constitution-engine.ts
+++ b/server/src/services/constitution-engine.ts
@@ -56,6 +56,10 @@ import {
   type EvaluationResult,
 } from "./evaluators.js";
 import { compileSystemPrompt } from "./prompt-compiler.js";
+import {
+  appendSteeringToLastUserMessage,
+  buildXLinkSteering,
+} from "./link-tool-routing.js";
 import { readUpdateAvailable } from "./system-update-check.js";
 import {
   getAgentSlug,
@@ -876,9 +880,19 @@ export class ConstitutionEngine {
     const useLeanResume = !!resumeSessionId && contextUnchanged && leanResumeEnabled();
     const effectiveSystemPrompt = useLeanResume ? buildLeanResumePrompt() : systemPrompt;
 
+    // Steer links that generic web search can't read (currently X/Twitter
+    // posts) to the household's dedicated reader tool — or, when no such tool
+    // is granted, forbid the agent from inventing a summary. The note is
+    // attached to THIS turn's user message so it applies on both resume
+    // (single current turn) and fresh (full history) paths. `tools` reflects
+    // the agent's actually-granted tool defs for this turn.
+    const linkSteering = buildXLinkSteering(message, tools ?? []);
     const messagesForLlm = resumeSessionId
-      ? [{ role: "user", content: currentTurnForLlm }]
-      : history;
+      ? appendSteeringToLastUserMessage(
+          [{ role: "user", content: currentTurnForLlm }],
+          linkSteering,
+        )
+      : appendSteeringToLastUserMessage(history, linkSteering);
     const messagesForLlmChars = messagesForLlm.reduce((sum, m) => sum + m.content.length, 0);
     perf.preSdkMs = Date.now() - perf.start;
 

--- a/server/src/services/link-tool-routing.ts
+++ b/server/src/services/link-tool-routing.ts
@@ -1,0 +1,176 @@
+/**
+ * Link → tool routing hints.
+ *
+ * Some content lives behind sources that generic WebSearch/WebFetch can't read
+ * reliably. X/Twitter is the canonical example: the public web view is
+ * JS-rendered and login-walled, so an agent that reaches for WebSearch when a
+ * user pastes an `x.com/.../status/...` link either fails or — worse —
+ * hallucinates a summary.
+ *
+ * The household may have a dedicated tool for this (e.g. `x_get_post`, backed
+ * by a live X data API). The model sees that tool in its tool list, but with
+ * dozens of tools available and WebSearch advertised prominently in its
+ * capabilities, it doesn't reliably connect "X link" → "use the X tool".
+ *
+ * This module closes that gap deterministically: when the user's message
+ * contains an X/Twitter post link, we inject a per-turn steering note that
+ * either (a) names the exact household tool to use, or (b) — if no such tool is
+ * available — tells the agent not to guess or invent the post's contents.
+ *
+ * Pure functions, no DB or network. Wired into the chat turn in
+ * constitution-engine.
+ */
+
+import type { ToolDefinition } from "@carsonos/shared";
+
+/**
+ * Match X/Twitter status URLs. Covers x.com, twitter.com, mobile.twitter.com,
+ * fxtwitter/vxtwitter mirrors, and optional `www.`/subdomains, with the
+ * `/<handle>/status/<id>` shape. Query strings (`?s=46`) are tolerated.
+ */
+const X_POST_URL_RE =
+  /https?:\/\/(?:[a-z0-9-]+\.)*(?:x|twitter|fxtwitter|vxtwitter|nitter|fixupx)\.com\/[A-Za-z0-9_]+\/status(?:es)?\/\d+(?:[/?#]\S*)?/gi;
+
+/**
+ * Extract distinct X/Twitter post URLs from a block of text.
+ * Trailing punctuation that commonly hugs pasted links is trimmed.
+ */
+export function detectXPostUrls(text: string): string[] {
+  if (!text) return [];
+  const matches = text.match(X_POST_URL_RE) ?? [];
+  const cleaned = matches.map((m) => m.replace(/[)\]}>.,;'"]+$/, ""));
+  return Array.from(new Set(cleaned));
+}
+
+/** Does this message reference at least one X/Twitter post? */
+export function hasXPostLink(text: string): boolean {
+  return detectXPostUrls(text).length > 0;
+}
+
+/**
+ * Find the best available tool for reading a *specific* X/Twitter post by URL.
+ *
+ * Preference order:
+ *   1. A tool that takes a `url` input and references X/Twitter posts — the
+ *      shape `x_get_post` has. Best fit for "read this exact link".
+ *   2. Any tool whose name/description references reading an X/Twitter
+ *      post/tweet/thread (fallback when the schema is opaque).
+ *
+ * Search tools (query-based, e.g. `x_search_posts`) are intentionally NOT
+ * matched — they answer "find posts about X", not "read this link".
+ *
+ * Returns the tool's callable name (what the model invokes), or null.
+ */
+export function findXPostTool(tools: ToolDefinition[]): string | null {
+  if (!tools || tools.length === 0) return null;
+
+  const candidates = tools.filter(isXReadingTool);
+  if (candidates.length === 0) return null;
+
+  // Prefer a tool that accepts a `url` input — that's the "fetch this exact
+  // post" shape, not a keyword search.
+  const withUrl = candidates.find(hasUrlInput);
+  return (withUrl ?? candidates[0]).name;
+}
+
+function isXReadingTool(tool: ToolDefinition): boolean {
+  const name = (tool.name ?? "").toLowerCase();
+  const desc = (tool.description ?? "").toLowerCase();
+
+  // Exclude obvious search/keyword tools — they don't read a specific link.
+  if (/search/.test(name)) return false;
+
+  const haystack = `${name} ${desc}`;
+  const mentionsX = /\b(x|twitter)\b|x\/twitter|tweet/.test(haystack);
+  if (!mentionsX) return false;
+
+  const mentionsPost = /\b(post|posts|tweet|tweets|thread|status)\b/.test(haystack);
+  const mentionsRead = /\b(get|read|fetch|load|view|open|retrieve)\b/.test(haystack);
+
+  // Strongest signal: the canonical name. Otherwise require both an X/Twitter
+  // reference AND a read+post intent so we don't grab unrelated tools.
+  return name === "x_get_post" || (mentionsPost && mentionsRead);
+}
+
+function hasUrlInput(tool: ToolDefinition): boolean {
+  const schema = tool.input_schema as
+    | { properties?: Record<string, unknown> }
+    | undefined;
+  const props = schema?.properties;
+  if (!props || typeof props !== "object") return false;
+  return Object.keys(props).some((k) => /url|link/i.test(k));
+}
+
+/**
+ * Build a per-turn steering note for a message containing X/Twitter link(s).
+ *
+ * Returns null when the message has no X link (the common case) so callers can
+ * skip injection entirely.
+ *
+ * Two outcomes:
+ *   - Tool available  → name it and forbid WebSearch / fabrication.
+ *   - No tool         → forbid guessing; tell the agent to be honest about the
+ *                       limitation rather than inventing a summary.
+ */
+export function buildXLinkSteering(
+  message: string,
+  tools: ToolDefinition[],
+): string | null {
+  const urls = detectXPostUrls(message);
+  if (urls.length === 0) return null;
+
+  const urlList = urls.map((u) => `- ${u}`).join("\n");
+  const toolName = findXPostTool(tools);
+
+  if (toolName) {
+    return [
+      "<system-reminder>",
+      `The user's message contains X/Twitter post link(s):`,
+      urlList,
+      "",
+      `Use the \`${toolName}\` tool to fetch the actual post content before you respond.`,
+      "Do NOT use web search or web fetch for X/Twitter links — they cannot read",
+      "X/Twitter reliably. Do NOT summarize, paraphrase, or guess the post from",
+      `memory or prior knowledge. Call \`${toolName}\` with the URL, then answer`,
+      "from what it returns. If the tool errors, say so plainly instead of guessing.",
+      "</system-reminder>",
+    ].join("\n");
+  }
+
+  return [
+    "<system-reminder>",
+    "The user's message contains X/Twitter post link(s):",
+    urlList,
+    "",
+    "You do not have a tool that can read X/Twitter posts, and web search cannot",
+    "read them reliably. Do NOT guess, summarize, or invent the post's contents.",
+    "Tell the user you can't open the link directly and ask them to paste the text",
+    "if they'd like you to help with it.",
+    "</system-reminder>",
+  ].join("\n");
+}
+
+/**
+ * Append a steering note to the last user message in a turn array, returning a
+ * new array. No-op (returns the same array) when the note is null/empty or
+ * there is no user message to attach to.
+ */
+export function appendSteeringToLastUserMessage<
+  T extends { role: string; content: string },
+>(messages: T[], note: string | null): T[] {
+  if (!note) return messages;
+  let lastUserIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "user") {
+      lastUserIdx = i;
+      break;
+    }
+  }
+  if (lastUserIdx === -1) return messages;
+  const copy = messages.slice();
+  copy[lastUserIdx] = {
+    ...copy[lastUserIdx],
+    content: `${copy[lastUserIdx].content}\n\n${note}`,
+  };
+  return copy;
+}


### PR DESCRIPTION
## Problem

Josh sent `https://x.com/pbakaus/status/2060208540992880794?s=46` and Carson reached for **WebSearch** (which can't read X reliably) instead of the household's `x_get_post` tool — and risked fabricating a summary. The tool was **active and granted**; the gap was purely **discovery**: the model sees `x_get_post` in its tool list, but the capabilities prompt advertises WebSearch prominently and nothing connected "X link" → "use the X tool".

## Fix

A deterministic per-turn steering note. When the current user message contains an X/Twitter post link, inject a `<system-reminder>` onto that turn that either:

1. **Names the exact household tool** to use and forbids web search / fabrication, or
2. **Forbids guessing** (when no X-reader is granted) and tells the agent to be honest about the limitation instead of inventing a summary.

### Changes
- New pure module `link-tool-routing.ts`: `detectXPostUrls`, `findXPostTool` (prefers a `url`-input "read this post" tool over keyword-search tools like `x_search_posts`), `buildXLinkSteering`, `appendSteeringToLastUserMessage`.
- Wired into the chat turn in `constitution-engine.ts` so it applies on both **resume** (single current turn) and **fresh** (full history) paths. Uses the agent's actually-granted tool defs, so it degrades gracefully when no X tool exists.

## Tests
- 19 new unit tests: URL detection (x.com, twitter.com, mobile/www, fx/vx mirrors, `?s=` query, trailing punctuation, dedupe, profile-link rejection), tool selection priority, and steering text for both tool-available and no-tool cases.
- Full suite green: **692 server tests + 53 UI tests**, typecheck clean.

## End-to-end verification (per Josh/Carson requirements)
1. **Tool works on the supplied URL** — decrypted the live `xai_api_key` secret and ran the `x_get_post` handler logic against the xAI responses API for `https://x.com/pbakaus/status/2060208540992880794`: **HTTP 200**, returned the real @pbakaus "Impeccable 3.5" post content (not a hallucination).
2. **Dependencies verified** — `x_get_post` is a pure fetch-based script tool (no Python deps). Node 22 present; `xai_api_key` secret present and valid on the host.
3. **Confirmed working end-to-end** before marking complete.

> Note: the running CarsonOS does not auto-restart on merge — restart manually to pick up the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)