### PR TITLE
fix(harness): separate Codex agent_message blocks in Telegram stream

### DIFF
--- a/server/src/services/harness/__tests__/codex-json.test.ts
+++ b/server/src/services/harness/__tests__/codex-json.test.ts
@@ -49,6 +49,26 @@ describe("CodexEventMapper", () => {
     expect(mapper.content).toBe("first\n\nsecond");
   });
 
+  it("streams a paragraph break before each agent_message after the first", () => {
+    // Regression: post-v0.6.0 the live Telegram stream glued consecutive Codex
+    // agent_message blocks together (e.g. "…anything.Checked.") because the
+    // streamed text_delta carried no separator, while the final `content` joins
+    // blocks with "\n\n". The streamed deltas must reconstruct `content` exactly.
+    const { events, mapper } = mapAll([
+      `{"type":"item.completed","item":{"type":"agent_message","text":"anything."}}`,
+      `{"type":"item.completed","item":{"type":"agent_message","text":"Checked."}}`,
+    ]);
+
+    const textDeltas = events
+      .filter((e): e is Extract<HarnessEvent, { type: "text_delta" }> => e.type === "text_delta")
+      .map((e) => e.text);
+
+    // First block has no leading separator; every later block carries "\n\n".
+    expect(textDeltas).toEqual(["anything.", "\n\nChecked."]);
+    // The streamed concatenation must equal the final content exactly.
+    expect(textDeltas.join("")).toBe(mapper.content);
+  });
+
   it("flags a failed tool call as isError", () => {
     const m = new CodexEventMapper();
     const events = m.handleLine(

--- a/server/src/services/harness/codex-json.ts
+++ b/server/src/services/harness/codex-json.ts
@@ -98,8 +98,14 @@ export class CodexEventMapper {
         const item = ev.item;
         if (!item) return [];
         if (item.type === "agent_message" && typeof item.text === "string") {
+          // Codex delivers each agent_message complete (no char deltas), and a
+          // turn may contain several blocks split by tool calls. The `content`
+          // getter joins them with a blank line, so every streamed delta after
+          // the first must carry the same "\n\n" separator — otherwise the live
+          // Telegram message glues sentences together (e.g. "…anything.Checked.").
+          const separator = this.contentParts.length > 0 ? "\n\n" : "";
           this.contentParts.push(item.text);
-          return [{ type: "text_delta", text: item.text }];
+          return [{ type: "text_delta", text: separator + item.text }];
         }
         if (item.type === "mcp_tool_call") {
           const resultText = item.result?.content


### PR DESCRIPTION
## Summary
Fixes a v0.6.0 streaming regression where the Codex harness glued
consecutive `agent_message` blocks together in the live Telegram message,
e.g. `…anything.Checked.` (confirmed by Josh's screenshot).

**Root cause:** `CodexEventMapper.content` joins agent-message blocks with
`"\n\n"`, but each streamed `text_delta` carried only the raw block text
with no separator. The Telegram streamer concatenates deltas raw
(`telegram-streaming.ts: accumulated += text`), so the live message had no
paragraph break between blocks — even though the final `done` content did.
The Claude path already emits an explicit `"\n\n"` between assistant
message blocks (`subprocess-adapter.ts:873-874`), so Codex was the
regressed seam.

**Fix (minimal):** `CodexEventMapper` now prepends `"\n\n"` to the
`text_delta` for every `agent_message` after the first, so the streamed
delta concatenation reconstructs `content` exactly.

## Files changed
- `server/src/services/harness/codex-json.ts` — prepend `"\n\n"` separator to deltas after the first agent_message
- `server/src/services/harness/__tests__/codex-json.test.ts` — regression test (failing before, passing after)

## Test plan
- [x] New regression test fails on `main`, passes with the fix
- [x] `pnpm test` — 674 server + 53 UI tests pass (full workspace green)
- [x] `pnpm typecheck` — clean across all 4 workspace projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)